### PR TITLE
feat: Phase 2 KPI tooling (fat-tail + regime t-test)

### DIFF
--- a/docs/kpi/fat_tail.json
+++ b/docs/kpi/fat_tail.json
@@ -1,0 +1,172 @@
+{
+  "by_symbol": {
+    "xyz:SP500": {
+      "R1_active": {
+        "n": 0,
+        "mean": 0.0,
+        "std": 0.0,
+        "skewness": 0.0,
+        "kurtosis": 0.0,
+        "hill_alpha": null,
+        "shapiro_pvalue": null,
+        "is_heavy_tail": false
+      },
+      "R2_closure_weekend": {
+        "n": 6342,
+        "mean": -0.04843472090825059,
+        "std": 3.2211401260302637,
+        "skewness": 0.7533223355449276,
+        "kurtosis": -0.3293866624269879,
+        "hill_alpha": 3.523716370128196,
+        "shapiro_pvalue": 2.957520305055387e-114,
+        "is_heavy_tail": true
+      },
+      "R3_closure_daily": {
+        "n": 0,
+        "mean": 0.0,
+        "std": 0.0,
+        "skewness": 0.0,
+        "kurtosis": 0.0,
+        "hill_alpha": null,
+        "shapiro_pvalue": null,
+        "is_heavy_tail": false
+      },
+      "R4_closure_holiday": {
+        "n": 0,
+        "mean": 0.0,
+        "std": 0.0,
+        "skewness": 0.0,
+        "kurtosis": 0.0,
+        "hill_alpha": null,
+        "shapiro_pvalue": null,
+        "is_heavy_tail": false
+      }
+    },
+    "xyz:XYZ100": {
+      "R1_active": {
+        "n": 0,
+        "mean": 0.0,
+        "std": 0.0,
+        "skewness": 0.0,
+        "kurtosis": 0.0,
+        "hill_alpha": null,
+        "shapiro_pvalue": null,
+        "is_heavy_tail": false
+      },
+      "R2_closure_weekend": {
+        "n": 6342,
+        "mean": 3.8941185745821243,
+        "std": 12.951425422336266,
+        "skewness": 0.30451247122649117,
+        "kurtosis": -0.21438244948242513,
+        "hill_alpha": 3.6601991966853547,
+        "shapiro_pvalue": 2.143919188844885e-24,
+        "is_heavy_tail": true
+      },
+      "R3_closure_daily": {
+        "n": 0,
+        "mean": 0.0,
+        "std": 0.0,
+        "skewness": 0.0,
+        "kurtosis": 0.0,
+        "hill_alpha": null,
+        "shapiro_pvalue": null,
+        "is_heavy_tail": false
+      },
+      "R4_closure_holiday": {
+        "n": 0,
+        "mean": 0.0,
+        "std": 0.0,
+        "skewness": 0.0,
+        "kurtosis": 0.0,
+        "hill_alpha": null,
+        "shapiro_pvalue": null,
+        "is_heavy_tail": false
+      }
+    },
+    "BTC": {
+      "R1_active": {
+        "n": 0,
+        "mean": 0.0,
+        "std": 0.0,
+        "skewness": 0.0,
+        "kurtosis": 0.0,
+        "hill_alpha": null,
+        "shapiro_pvalue": null,
+        "is_heavy_tail": false
+      },
+      "R2_closure_weekend": {
+        "n": 6342,
+        "mean": -35.01843267108147,
+        "std": 7.282648247932425,
+        "skewness": -0.4171121733731497,
+        "kurtosis": -0.26066596529992125,
+        "hill_alpha": 12.999053287802102,
+        "shapiro_pvalue": 8.37714149698451e-43,
+        "is_heavy_tail": false
+      },
+      "R3_closure_daily": {
+        "n": 0,
+        "mean": 0.0,
+        "std": 0.0,
+        "skewness": 0.0,
+        "kurtosis": 0.0,
+        "hill_alpha": null,
+        "shapiro_pvalue": null,
+        "is_heavy_tail": false
+      },
+      "R4_closure_holiday": {
+        "n": 0,
+        "mean": 0.0,
+        "std": 0.0,
+        "skewness": 0.0,
+        "kurtosis": 0.0,
+        "hill_alpha": null,
+        "shapiro_pvalue": null,
+        "is_heavy_tail": false
+      }
+    },
+    "ETH": {
+      "R1_active": {
+        "n": 0,
+        "mean": 0.0,
+        "std": 0.0,
+        "skewness": 0.0,
+        "kurtosis": 0.0,
+        "hill_alpha": null,
+        "shapiro_pvalue": null,
+        "is_heavy_tail": false
+      },
+      "R2_closure_weekend": {
+        "n": 6342,
+        "mean": -1.0182639545884777,
+        "std": 0.15601186294039016,
+        "skewness": 0.3877996239129457,
+        "kurtosis": 0.7655575851611753,
+        "hill_alpha": 14.14423487224671,
+        "shapiro_pvalue": 2.2612744453460577e-51,
+        "is_heavy_tail": false
+      },
+      "R3_closure_daily": {
+        "n": 0,
+        "mean": 0.0,
+        "std": 0.0,
+        "skewness": 0.0,
+        "kurtosis": 0.0,
+        "hill_alpha": null,
+        "shapiro_pvalue": null,
+        "is_heavy_tail": false
+      },
+      "R4_closure_holiday": {
+        "n": 0,
+        "mean": 0.0,
+        "std": 0.0,
+        "skewness": 0.0,
+        "kurtosis": 0.0,
+        "hill_alpha": null,
+        "shapiro_pvalue": null,
+        "is_heavy_tail": false
+      }
+    }
+  }
+}

--- a/docs/kpi/fat_tail.md
+++ b/docs/kpi/fat_tail.md
@@ -1,0 +1,47 @@
+# Phase 2 KPI: 分布のファットテール定量化
+
+v3 design §3 K10/K11 の前段. regime 別 IPD 分布の正規性を Hill 推定 + Shapiro-Wilk で検定.
+
+## xyz:SP500
+
+| regime | n | mean | std | skew | kurt | hill_alpha | shapiro_p | heavy? |
+|---|---|---|---|---|---|---|---|---|
+| R1_active | 0 | - | - | - | - | - | - | - |
+| R2_closure_weekend | 6342 | -0.048 | 3.221 | +0.75 | -0.33 | 3.52 | 0.0000 | YES |
+| R3_closure_daily | 0 | - | - | - | - | - | - | - |
+| R4_closure_holiday | 0 | - | - | - | - | - | - | - |
+
+## xyz:XYZ100
+
+| regime | n | mean | std | skew | kurt | hill_alpha | shapiro_p | heavy? |
+|---|---|---|---|---|---|---|---|---|
+| R1_active | 0 | - | - | - | - | - | - | - |
+| R2_closure_weekend | 6342 | +3.894 | 12.951 | +0.30 | -0.21 | 3.66 | 0.0000 | YES |
+| R3_closure_daily | 0 | - | - | - | - | - | - | - |
+| R4_closure_holiday | 0 | - | - | - | - | - | - | - |
+
+## BTC
+
+| regime | n | mean | std | skew | kurt | hill_alpha | shapiro_p | heavy? |
+|---|---|---|---|---|---|---|---|---|
+| R1_active | 0 | - | - | - | - | - | - | - |
+| R2_closure_weekend | 6342 | -35.018 | 7.283 | -0.42 | -0.26 | 13.00 | 0.0000 | no |
+| R3_closure_daily | 0 | - | - | - | - | - | - | - |
+| R4_closure_holiday | 0 | - | - | - | - | - | - | - |
+
+## ETH
+
+| regime | n | mean | std | skew | kurt | hill_alpha | shapiro_p | heavy? |
+|---|---|---|---|---|---|---|---|---|
+| R1_active | 0 | - | - | - | - | - | - | - |
+| R2_closure_weekend | 6342 | -1.018 | 0.156 | +0.39 | +0.77 | 14.14 | 0.0000 | no |
+| R3_closure_daily | 0 | - | - | - | - | - | - | - |
+| R4_closure_holiday | 0 | - | - | - | - | - | - | - |
+
+## 解釈ガイド
+
+- **kurt > 3**: 正規分布よりピーク鋭く, 裾が厚い (heavy-tail)
+- **hill_alpha < 4**: tail がべき乗則に近い heavy-tail
+- **shapiro_pvalue < 0.05**: 正規性棄却 (CLT 収束遅い)
+- heavy=YES の regime は LLN/CLT で平均±k·σ/√N の信頼区間が信用できない
+- Phase 2 採否判定: heavy-tail 銘柄/regime は分布 tail を直接狙う戦略にする

--- a/docs/kpi/regime_diff.json
+++ b/docs/kpi/regime_diff.json
@@ -1,0 +1,72 @@
+{
+  "by_symbol": {
+    "xyz:SP500": {
+      "R2_closure_weekend_vs_R3_closure_daily": {
+        "n_a": 6342,
+        "n_b": 0,
+        "warning": "insufficient samples"
+      },
+      "R2_closure_weekend_vs_R4_closure_holiday": {
+        "n_a": 6342,
+        "n_b": 0,
+        "warning": "insufficient samples"
+      },
+      "R3_closure_daily_vs_R4_closure_holiday": {
+        "n_a": 0,
+        "n_b": 0,
+        "warning": "insufficient samples"
+      }
+    },
+    "xyz:XYZ100": {
+      "R2_closure_weekend_vs_R3_closure_daily": {
+        "n_a": 6342,
+        "n_b": 0,
+        "warning": "insufficient samples"
+      },
+      "R2_closure_weekend_vs_R4_closure_holiday": {
+        "n_a": 6342,
+        "n_b": 0,
+        "warning": "insufficient samples"
+      },
+      "R3_closure_daily_vs_R4_closure_holiday": {
+        "n_a": 0,
+        "n_b": 0,
+        "warning": "insufficient samples"
+      }
+    },
+    "BTC": {
+      "R2_closure_weekend_vs_R3_closure_daily": {
+        "n_a": 6342,
+        "n_b": 0,
+        "warning": "insufficient samples"
+      },
+      "R2_closure_weekend_vs_R4_closure_holiday": {
+        "n_a": 6342,
+        "n_b": 0,
+        "warning": "insufficient samples"
+      },
+      "R3_closure_daily_vs_R4_closure_holiday": {
+        "n_a": 0,
+        "n_b": 0,
+        "warning": "insufficient samples"
+      }
+    },
+    "ETH": {
+      "R2_closure_weekend_vs_R3_closure_daily": {
+        "n_a": 6342,
+        "n_b": 0,
+        "warning": "insufficient samples"
+      },
+      "R2_closure_weekend_vs_R4_closure_holiday": {
+        "n_a": 6342,
+        "n_b": 0,
+        "warning": "insufficient samples"
+      },
+      "R3_closure_daily_vs_R4_closure_holiday": {
+        "n_a": 0,
+        "n_b": 0,
+        "warning": "insufficient samples"
+      }
+    }
+  }
+}

--- a/docs/kpi/regime_diff.md
+++ b/docs/kpi/regime_diff.md
@@ -1,0 +1,41 @@
+# Phase 2 KPI: regime 間 IPD ドリフト有意差検定 (Welch's t-test)
+
+v3 design §3 K1 の延長. R2 (週末) / R3 (CMEメンテ) / R4 (祝日) の IPD bar 分布が 統計的に異なるかを検定. p<0.05 なら戦略 H1 を regime 別にチューニング.
+
+## xyz:SP500
+
+| pair | n_a | n_b | t_stat | p_value | significant (p<0.05) |
+|---|---|---|---|---|---|
+| R2_closure_weekend_vs_R3_closure_daily | 6342 | 0 | - | - | (warn) |
+| R2_closure_weekend_vs_R4_closure_holiday | 6342 | 0 | - | - | (warn) |
+| R3_closure_daily_vs_R4_closure_holiday | 0 | 0 | - | - | (warn) |
+
+## xyz:XYZ100
+
+| pair | n_a | n_b | t_stat | p_value | significant (p<0.05) |
+|---|---|---|---|---|---|
+| R2_closure_weekend_vs_R3_closure_daily | 6342 | 0 | - | - | (warn) |
+| R2_closure_weekend_vs_R4_closure_holiday | 6342 | 0 | - | - | (warn) |
+| R3_closure_daily_vs_R4_closure_holiday | 0 | 0 | - | - | (warn) |
+
+## BTC
+
+| pair | n_a | n_b | t_stat | p_value | significant (p<0.05) |
+|---|---|---|---|---|---|
+| R2_closure_weekend_vs_R3_closure_daily | 6342 | 0 | - | - | (warn) |
+| R2_closure_weekend_vs_R4_closure_holiday | 6342 | 0 | - | - | (warn) |
+| R3_closure_daily_vs_R4_closure_holiday | 0 | 0 | - | - | (warn) |
+
+## ETH
+
+| pair | n_a | n_b | t_stat | p_value | significant (p<0.05) |
+|---|---|---|---|---|---|
+| R2_closure_weekend_vs_R3_closure_daily | 6342 | 0 | - | - | (warn) |
+| R2_closure_weekend_vs_R4_closure_holiday | 6342 | 0 | - | - | (warn) |
+| R3_closure_daily_vs_R4_closure_holiday | 0 | 0 | - | - | (warn) |
+
+## 解釈ガイド
+
+- **p < 0.05** = 2 regime の IPD 平均が有意に異なる
+- 全 pair で有意 → regime 別パラメータ必須
+- 全 pair で非有意 → 共通パラメータで H1 を統一できる

--- a/scripts/kpi_fat_tail.py
+++ b/scripts/kpi_fat_tail.py
@@ -1,0 +1,143 @@
+"""Phase 2 KPI: ファットテール定量化 (Issue #38).
+
+regime 別に IPD bar 値の分布形状を解析:
+- Hill 推定で tail index alpha
+- Shapiro-Wilk / D'Agostino-Pearson 正規性検定
+- skewness / kurtosis
+
+入力: data/curated/features/*.parquet
+出力: docs/kpi/fat_tail.{md,json}
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import polars as pl
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from _common import safe_read_parquet_glob  # noqa: E402
+
+from src.config import load_config  # noqa: E402
+from src.l2_features.distribution import analyze_distribution  # noqa: E402
+from src.l2_features.regime import Regime  # noqa: E402
+
+TARGET_SYMBOLS = ["xyz:SP500", "xyz:XYZ100", "BTC", "ETH"]
+ALL_REGIMES = [
+    Regime.ACTIVE.value,
+    Regime.CLOSURE_WEEKEND.value,
+    Regime.CLOSURE_DAILY.value,
+    Regime.CLOSURE_HOLIDAY.value,
+]
+
+
+def compute() -> dict[str, Any]:
+    cfg = load_config(
+        [
+            REPO_ROOT / "config" / "default.yaml",
+            REPO_ROOT / "config" / "local.yaml",
+        ]
+    )
+    glob = str(cfg.storage.curated_data_root / "features" / "**" / "*.parquet")
+    df = safe_read_parquet_glob(glob)
+    if df.is_empty():
+        return {"warning": "no curated features yet"}
+
+    by_symbol: dict[str, dict[str, Any]] = {}
+    for sym in TARGET_SYMBOLS:
+        sub_sym = df.filter(pl.col("symbol") == sym)
+        if sub_sym.is_empty():
+            by_symbol[sym] = {"warning": "no data"}
+            continue
+        per_regime: dict[str, dict[str, Any]] = {}
+        for regime in ALL_REGIMES:
+            sub = sub_sym.filter(pl.col("regime") == regime)["ipd"].drop_nulls()
+            values = [float(v) for v in sub.to_list()]
+            stats = analyze_distribution(values)
+            per_regime[regime] = {
+                "n": stats.n,
+                "mean": stats.mean,
+                "std": stats.std,
+                "skewness": stats.skewness,
+                "kurtosis": stats.kurtosis,
+                "hill_alpha": stats.hill_alpha,
+                "shapiro_pvalue": stats.shapiro_pvalue,
+                "is_heavy_tail": stats.is_heavy_tail,
+            }
+        by_symbol[sym] = per_regime
+    return {"by_symbol": by_symbol}
+
+
+def write_report(result: dict[str, Any]) -> Path:
+    out_dir = REPO_ROOT / "docs" / "kpi"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_md = out_dir / "fat_tail.md"
+    out_json = out_dir / "fat_tail.json"
+    out_json.write_text(json.dumps(result, indent=2, default=str), encoding="utf-8")
+
+    lines: list[str] = []
+    lines.append("# Phase 2 KPI: 分布のファットテール定量化")
+    lines.append("")
+    lines.append(
+        "v3 design §3 K10/K11 の前段. regime 別 IPD 分布の正規性を Hill 推定 + Shapiro-Wilk で検定."
+    )
+    lines.append("")
+    if result.get("warning"):
+        lines.append(f"> ⚠ **WARNING**: {result['warning']}")
+        lines.append("")
+        out_md.write_text("\n".join(lines), encoding="utf-8")
+        return out_md
+
+    by_symbol = result.get("by_symbol", {})
+    for sym, per_regime in by_symbol.items():
+        if isinstance(per_regime, dict) and per_regime.get("warning"):
+            lines.append(f"## {sym}: {per_regime['warning']}")
+            lines.append("")
+            continue
+        lines.append(f"## {sym}")
+        lines.append("")
+        lines.append("| regime | n | mean | std | skew | kurt | hill_alpha | shapiro_p | heavy? |")
+        lines.append("|---|---|---|---|---|---|---|---|---|")
+        for regime, stat in per_regime.items():
+            if stat.get("n", 0) < 8:
+                lines.append(f"| {regime} | {stat.get('n', 0)} | - | - | - | - | - | - | - |")
+                continue
+            ha = stat.get("hill_alpha")
+            sp = stat.get("shapiro_pvalue")
+            ha_s = f"{ha:.2f}" if ha is not None else "-"
+            sp_s = f"{sp:.4f}" if sp is not None else "-"
+            heavy = "YES" if stat.get("is_heavy_tail") else "no"
+            lines.append(
+                f"| {regime} | {stat['n']} | {stat['mean']:+.3f} | {stat['std']:.3f} | "
+                f"{stat['skewness']:+.2f} | {stat['kurtosis']:+.2f} | {ha_s} | {sp_s} | {heavy} |"
+            )
+        lines.append("")
+
+    lines.append("## 解釈ガイド")
+    lines.append("")
+    lines.append("- **kurt > 3**: 正規分布よりピーク鋭く, 裾が厚い (heavy-tail)")
+    lines.append("- **hill_alpha < 4**: tail がべき乗則に近い heavy-tail")
+    lines.append("- **shapiro_pvalue < 0.05**: 正規性棄却 (CLT 収束遅い)")
+    lines.append(
+        "- heavy=YES の regime は LLN/CLT で mean+/-k*sigma/sqrt(N) の信頼区間が信用できない"
+    )
+    lines.append("- Phase 2 採否判定: heavy-tail 銘柄/regime は分布 tail を直接狙う戦略にする")
+
+    out_md.write_text("\n".join(lines), encoding="utf-8")
+    return out_md
+
+
+def main() -> None:
+    result = compute()
+    md = write_report(result)
+    print(f"fat_tail report: {md}")
+    print(json.dumps(result, indent=2, default=str)[:1500])
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/kpi_regime_diff_test.py
+++ b/scripts/kpi_regime_diff_test.py
@@ -1,0 +1,146 @@
+"""Phase 2 KPI: regime 間の IPD ドリフト有意差検定 (Issue #39).
+
+Welch's t-test (不等分散) で R2 (週末) / R3 (CMEメンテ) / R4 (祝日) の
+IPD 分布が統計的に異なるかを検定. p<0.05 なら regime 別チューニング要.
+
+入力: data/curated/features/*.parquet
+出力: docs/kpi/regime_diff.{md,json}
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from itertools import combinations
+from pathlib import Path
+from typing import Any
+
+import polars as pl
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from _common import safe_read_parquet_glob  # noqa: E402
+
+from src.config import load_config  # noqa: E402
+from src.l2_features.distribution import welch_t_test  # noqa: E402
+from src.l2_features.regime import Regime  # noqa: E402
+
+TARGET_SYMBOLS = ["xyz:SP500", "xyz:XYZ100", "BTC", "ETH"]
+TARGET_REGIMES = [
+    Regime.CLOSURE_WEEKEND.value,
+    Regime.CLOSURE_DAILY.value,
+    Regime.CLOSURE_HOLIDAY.value,
+]
+
+
+def compute() -> dict[str, Any]:
+    cfg = load_config(
+        [
+            REPO_ROOT / "config" / "default.yaml",
+            REPO_ROOT / "config" / "local.yaml",
+        ]
+    )
+    glob = str(cfg.storage.curated_data_root / "features" / "**" / "*.parquet")
+    df = safe_read_parquet_glob(glob)
+    if df.is_empty():
+        return {"warning": "no curated features yet"}
+
+    by_symbol: dict[str, dict[str, Any]] = {}
+    for sym in TARGET_SYMBOLS:
+        sub_sym = df.filter(pl.col("symbol") == sym)
+        if sub_sym.is_empty():
+            by_symbol[sym] = {"warning": "no data"}
+            continue
+        regime_samples: dict[str, list[float]] = {}
+        for regime in TARGET_REGIMES:
+            ipd = sub_sym.filter(pl.col("regime") == regime)["ipd"].drop_nulls()
+            regime_samples[regime] = [float(v) for v in ipd.to_list()]
+
+        pairs: dict[str, dict[str, Any]] = {}
+        for r_a, r_b in combinations(TARGET_REGIMES, 2):
+            a = regime_samples[r_a]
+            b = regime_samples[r_b]
+            if len(a) < 2 or len(b) < 2:
+                pairs[f"{r_a}_vs_{r_b}"] = {
+                    "n_a": len(a),
+                    "n_b": len(b),
+                    "warning": "insufficient samples",
+                }
+                continue
+            t, p = welch_t_test(a, b)
+            pairs[f"{r_a}_vs_{r_b}"] = {
+                "n_a": len(a),
+                "n_b": len(b),
+                "t_stat": t,
+                "p_value": p,
+                "is_significant_005": p < 0.05,
+            }
+        by_symbol[sym] = pairs
+
+    return {"by_symbol": by_symbol}
+
+
+def write_report(result: dict[str, Any]) -> Path:
+    out_dir = REPO_ROOT / "docs" / "kpi"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_md = out_dir / "regime_diff.md"
+    out_json = out_dir / "regime_diff.json"
+    out_json.write_text(json.dumps(result, indent=2, default=str), encoding="utf-8")
+
+    lines: list[str] = []
+    lines.append("# Phase 2 KPI: regime 間 IPD ドリフト有意差検定 (Welch's t-test)")
+    lines.append("")
+    lines.append(
+        "v3 design §3 K1 の延長. R2 (週末) / R3 (CMEメンテ) / R4 (祝日) の IPD bar 分布が "
+        "統計的に異なるかを検定. p<0.05 なら戦略 H1 を regime 別にチューニング."
+    )
+    lines.append("")
+    if result.get("warning"):
+        lines.append(f"> ⚠ **WARNING**: {result['warning']}")
+        lines.append("")
+        out_md.write_text("\n".join(lines), encoding="utf-8")
+        return out_md
+
+    by_symbol = result.get("by_symbol", {})
+    for sym, pairs in by_symbol.items():
+        if isinstance(pairs, dict) and pairs.get("warning"):
+            lines.append(f"## {sym}: {pairs['warning']}")
+            lines.append("")
+            continue
+        lines.append(f"## {sym}")
+        lines.append("")
+        lines.append("| pair | n_a | n_b | t_stat | p_value | significant (p<0.05) |")
+        lines.append("|---|---|---|---|---|---|")
+        for pair, stat in pairs.items():
+            if stat.get("warning"):
+                lines.append(
+                    f"| {pair} | {stat.get('n_a', 0)} | {stat.get('n_b', 0)} | - | - | (warn) |"
+                )
+                continue
+            sig = "**YES**" if stat["is_significant_005"] else "no"
+            lines.append(
+                f"| {pair} | {stat['n_a']} | {stat['n_b']} | "
+                f"{stat['t_stat']:+.3f} | {stat['p_value']:.4f} | {sig} |"
+            )
+        lines.append("")
+
+    lines.append("## 解釈ガイド")
+    lines.append("")
+    lines.append("- **p < 0.05** = 2 regime の IPD 平均が有意に異なる")
+    lines.append("- 全 pair で有意 → regime 別パラメータ必須")
+    lines.append("- 全 pair で非有意 → 共通パラメータで H1 を統一できる")
+
+    out_md.write_text("\n".join(lines), encoding="utf-8")
+    return out_md
+
+
+def main() -> None:
+    result = compute()
+    md = write_report(result)
+    print(f"regime_diff report: {md}")
+    print(json.dumps(result, indent=2, default=str)[:1500])
+
+
+if __name__ == "__main__":
+    main()

--- a/src/l2_features/distribution.py
+++ b/src/l2_features/distribution.py
@@ -1,0 +1,118 @@
+"""分布解析: Hill 推定 + Shapiro-Wilk + 正規性 Q-Q 評価.
+
+LLN/CLT 適用可否の判断に使う. heavy-tail (Hill alpha < 4) なら CLT 収束は遅く,
+小サンプルで信頼区間を作っても overfitting する.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+from scipy import stats
+
+
+@dataclass
+class DistributionStats:
+    n: int
+    mean: float
+    std: float
+    skewness: float
+    kurtosis: float  # Fisher 定義 (正規分布で 0)
+    hill_alpha: float | None  # tail index, < 4 で heavy-tail
+    shapiro_pvalue: float | None  # 正規性 (>0.05 で正規性棄却できず)
+    is_heavy_tail: bool
+
+
+def hill_estimator(values: list[float] | np.ndarray, k_ratio: float = 0.1) -> float | None:
+    """Hill 推定で tail index alpha を求める.
+
+    alpha が小さいほどヘビーテール. 一般に alpha < 4 で fat-tail とみなす.
+    上位 k = n * k_ratio 件の order statistics を使う.
+
+    Returns:
+        alpha: 推定 tail index. データ少なすぎ・分散ゼロ等は None.
+    """
+    arr = np.asarray(values, dtype=float)
+    arr = arr[np.isfinite(arr) & (arr > 0)]  # 正値のみ (右側 tail)
+    n = len(arr)
+    if n < 30:
+        return None
+    arr_sorted = np.sort(arr)[::-1]  # 降順
+    k = max(int(n * k_ratio), 10)
+    if k >= n:
+        k = n - 1
+    top_k = arr_sorted[:k]
+    threshold = arr_sorted[k]
+    if threshold <= 0:
+        return None
+    log_ratios = np.log(top_k / threshold)
+    if log_ratios.sum() <= 0:
+        return None
+    alpha = 1.0 / np.mean(log_ratios)
+    return float(alpha)
+
+
+def shapiro_wilk_pvalue(values: list[float] | np.ndarray) -> float | None:
+    """Shapiro-Wilk p-value (>0.05 = 正規性を棄却できない).
+
+    n>5000 では使えないので scipy.stats.normaltest にフォールバック.
+    """
+    arr = np.asarray(values, dtype=float)
+    arr = arr[np.isfinite(arr)]
+    n = len(arr)
+    if n < 8:
+        return None
+    if n > 5000:
+        # large sample: D'Agostino-Pearson normaltest
+        _, p = stats.normaltest(arr)
+        return float(p)
+    _, p = stats.shapiro(arr)
+    return float(p)
+
+
+def analyze_distribution(values: list[float] | np.ndarray) -> DistributionStats:
+    """分布の総合解析."""
+    arr = np.asarray(values, dtype=float)
+    arr = arr[np.isfinite(arr)]
+    n = len(arr)
+    if n == 0:
+        return DistributionStats(0, 0.0, 0.0, 0.0, 0.0, None, None, False)
+    mean = float(arr.mean())
+    std = float(arr.std())
+    skew = float(stats.skew(arr)) if n > 2 else 0.0
+    kurt = float(stats.kurtosis(arr)) if n > 3 else 0.0  # Fisher (正規 = 0)
+    abs_arr = np.abs(arr)
+    abs_arr = abs_arr[abs_arr > 0]
+    hill_alpha = hill_estimator(abs_arr) if len(abs_arr) >= 30 else None
+    shapiro_p = shapiro_wilk_pvalue(arr)
+    is_heavy = (hill_alpha is not None and hill_alpha < 4.0) or (kurt > 3.0)
+    return DistributionStats(
+        n=n,
+        mean=mean,
+        std=std,
+        skewness=skew,
+        kurtosis=kurt,
+        hill_alpha=hill_alpha,
+        shapiro_pvalue=shapiro_p,
+        is_heavy_tail=is_heavy,
+    )
+
+
+def welch_t_test(
+    sample_a: list[float] | np.ndarray,
+    sample_b: list[float] | np.ndarray,
+) -> tuple[float, float]:
+    """2 サンプルの Welch t-test (不等分散).
+
+    Returns:
+        (t_statistic, p_value).  p < 0.05 で有意差あり.
+    """
+    a = np.asarray(sample_a, dtype=float)
+    b = np.asarray(sample_b, dtype=float)
+    a = a[np.isfinite(a)]
+    b = b[np.isfinite(b)]
+    if len(a) < 2 or len(b) < 2:
+        return (float("nan"), 1.0)
+    t, p = stats.ttest_ind(a, b, equal_var=False)
+    return (float(t), float(p))

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -1,0 +1,61 @@
+"""distribution.py の Hill 推定 + Shapiro-Wilk + Welch t-test テスト."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from src.l2_features.distribution import (
+    analyze_distribution,
+    hill_estimator,
+    shapiro_wilk_pvalue,
+    welch_t_test,
+)
+
+
+def test_normal_data_not_heavy_tail() -> None:
+    """正規分布: kurtosis ~0, shapiro p>0.05 で heavy=False."""
+    rng = np.random.default_rng(42)
+    samples = rng.standard_normal(500).tolist()
+    res = analyze_distribution(samples)
+    assert res.n == 500
+    assert abs(res.kurtosis) < 1.0  # near 0
+    assert res.shapiro_pvalue is not None
+    assert not res.is_heavy_tail
+
+
+def test_pareto_is_heavy_tail() -> None:
+    """Pareto (alpha=2.5) の正値サンプル: heavy_tail=True."""
+    rng = np.random.default_rng(7)
+    samples = (rng.pareto(a=2.5, size=500) + 1).tolist()
+    res = analyze_distribution(samples)
+    assert res.is_heavy_tail
+
+
+def test_hill_estimator_recovers_pareto_alpha() -> None:
+    """Pareto(alpha=3) で hill_estimator が ~3 を返す (誤差許容)."""
+    rng = np.random.default_rng(123)
+    samples = (rng.pareto(a=3.0, size=2000) + 1).tolist()
+    alpha = hill_estimator(samples, k_ratio=0.05)
+    assert alpha is not None
+    assert 1.5 < alpha < 6.0
+
+
+def test_shapiro_short_series_returns_none() -> None:
+    assert shapiro_wilk_pvalue([1.0, 2.0]) is None
+
+
+def test_welch_t_test_separates_means() -> None:
+    rng = np.random.default_rng(1)
+    a = (rng.standard_normal(200) + 0.5).tolist()
+    b = (rng.standard_normal(200) - 0.5).tolist()
+    t, p = welch_t_test(a, b)
+    assert p < 0.05
+    assert t > 0  # a > b
+
+
+def test_welch_t_test_same_distribution_no_significance() -> None:
+    rng = np.random.default_rng(99)
+    a = rng.standard_normal(200).tolist()
+    b = rng.standard_normal(200).tolist()
+    _, p = welch_t_test(a, b)
+    assert p > 0.01  # likely > 0.01 with same distribution


### PR DESCRIPTION
## Summary
Phase 2 KPI 採否判定の前段ツール. 1週間 collect 後に実分布で実行可.

## Linked Issues
- Closes #38 (fat-tail)
- Closes #39 (regime t-test)

## Type
- [x] feat
- [x] kpi

## Layer
- [x] L2 (distribution module)
- [x] cross-cutting (KPI scripts)

## DoD
- [x] ruff/format clean
- [x] 37/37 tests pass
- [x] 合成データで Hill 推定 / Welch t-test の精度確認

## Notes
合成データ (Pareto alpha=3) で hill_estimator が 1.5-6.0 範囲に入ることを確認.
Welch t-test は平均差 1σ で正しく p<0.05 判定.

🤖 Generated with [Claude Code](https://claude.com/claude-code)