### PR TITLE
feat: Strategies H2 (Crypto Native) + H3 (CME maintenance)

### DIFF
--- a/src/l3_strategy/strategies/h2_crypto_native.py
+++ b/src/l3_strategy/strategies/h2_crypto_native.py
@@ -1,0 +1,71 @@
+"""戦略 H2: Crypto Native 相関 (Issue #36).
+
+仮説 (v3 §2.2): closure 中, HL TradFi perp は BTC/ETH の動きに引きずられる.
+Phase 1 K8 で過去相関を分析した結果を踏まえ, 高相関期間で BTC 急変動と同方向にベット.
+
+エントリー条件:
+- regime in (R2, R3, R4) かつ regime_uncertain=False
+- 直近 N bar の BTC リターン累積が ±閾値超
+- 同方向 (long/short) を TradFi perp で取る
+
+エグジット:
+- holding timeout (BacktestEngine の exit_after_minutes)
+- IPD 反転 (drift が逆向きに進んだら早期 exit) — Phase 2 で追加
+
+依存: MarketState.extras に BTC ベンチマークの crypto_ret_cum を入れる
+(Phase 2 で L2 pipeline 拡張要. 暫定: state.extras.get('btc_ret_cum'))
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from src.l3_strategy.interface import MarketState, Side, Signal, Strategy
+
+CLOSURE_REGIMES = {
+    "R2_closure_weekend",
+    "R3_closure_daily",
+    "R4_closure_holiday",
+}
+
+EXTRA_BTC_RET_KEY = "btc_ret_cum"  # MarketState.extras から取る key
+
+
+@dataclass
+class H2CryptoNative(Strategy):
+    name: str = "H2_crypto_native"
+    btc_ret_threshold: float = 0.005  # 0.5% in window
+    base_size_usd: float = 1000.0
+    expected_pnl_bps: float = 10.0
+    target_symbols: tuple[str, ...] = ("xyz:SP500", "xyz:XYZ100")
+    _signal_buffer: dict = field(default_factory=dict)
+
+    def on_bar(self, state: MarketState) -> Signal | None:
+        if state.regime not in CLOSURE_REGIMES:
+            return None
+        if state.symbol not in self.target_symbols:
+            return None
+        btc_ret_cum = state.extras.get(EXTRA_BTC_RET_KEY)
+        if btc_ret_cum is None:
+            return None
+
+        side: Side = "flat"
+        if btc_ret_cum > self.btc_ret_threshold:
+            side = "long"
+        elif btc_ret_cum < -self.btc_ret_threshold:
+            side = "short"
+        else:
+            return None
+
+        return Signal(
+            timestamp=state.timestamp,
+            symbol=state.symbol,
+            side=side,
+            size_usd=self.base_size_usd,
+            expected_pnl_bps=self.expected_pnl_bps,
+            confidence=min(abs(btc_ret_cum) / (self.btc_ret_threshold * 2), 1.0),
+            metadata={
+                "btc_ret_cum": btc_ret_cum,
+                "regime": state.regime,
+            },
+        )

--- a/src/l3_strategy/strategies/h3_cme_maintenance.py
+++ b/src/l3_strategy/strategies/h3_cme_maintenance.py
@@ -1,0 +1,76 @@
+"""戦略 H3: CMEメンテ mini-closure 戻り取り (Issue #37).
+
+仮説 (v3 §2.3): 毎日 17-18 ET の CMEメンテ時間中, HL内部 EMA が IPD 累積で
+ドリフトする. メンテ終了 (18:00 ET) で oracle が CME EMM6 にワープ復帰
+するため, ドリフト方向と反対にエントリーすれば mean reversion で取れる.
+
+エントリー条件:
+- regime == R3 (CLOSURE_DAILY)
+- IPD 累積が ±閾値超
+- regime_uncertain=False (境界 buffer 除外)
+
+エグジット:
+- regime が R3 から R1 (active) に切り替わる瞬間 = oracle ワープ
+- BacktestEngine の exit_after_minutes でも fallback
+
+H1 (week 末) と H3 (CMEメンテ) の論理は対称. H1 と組合せて年間サンプル N>=500 達成を狙う.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass, field
+
+from src.l3_strategy.interface import MarketState, Side, Signal, Strategy
+
+
+@dataclass
+class H3CmeMaintenance(Strategy):
+    name: str = "H3_cme_maintenance"
+    window: int = 20
+    cum_ipd_entry_threshold: float = 3.0
+    base_size_usd: float = 1000.0
+    expected_pnl_bps: float = 12.0
+    _hist: dict[str, deque[float]] = field(default_factory=dict)
+
+    def on_bar(self, state: MarketState) -> Signal | None:
+        # CMEメンテ regime のみ
+        if state.regime != "R3_closure_daily":
+            self._hist.pop(state.symbol, None)
+            return None
+        if state.regime_uncertain:
+            return None
+        if state.ipd is None:
+            return None
+
+        buf = self._hist.setdefault(state.symbol, deque(maxlen=self.window))
+        buf.append(state.ipd)
+        if len(buf) < self.window:
+            return None
+
+        cum = sum(buf)
+        side: Side = "flat"
+        # ドリフト方向と反対 (mean reversion)
+        if cum > self.cum_ipd_entry_threshold:
+            side = "short"
+        elif cum < -self.cum_ipd_entry_threshold:
+            side = "long"
+        else:
+            return None
+
+        return Signal(
+            timestamp=state.timestamp,
+            symbol=state.symbol,
+            side=side,
+            size_usd=self.base_size_usd,
+            expected_pnl_bps=self.expected_pnl_bps,
+            confidence=min(abs(cum) / self.cum_ipd_entry_threshold, 3.0) / 3.0,
+            metadata={
+                "cum_ipd": cum,
+                "window": self.window,
+                "regime": "R3_closure_daily",
+            },
+        )
+
+    def warmup_bars(self) -> int:
+        return self.window

--- a/tests/test_h2_h3_strategies.py
+++ b/tests/test_h2_h3_strategies.py
@@ -1,0 +1,96 @@
+"""戦略 H2 / H3 の動作テスト (合成データ)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from src.l3_strategy.interface import MarketState, Signal
+from src.l3_strategy.strategies.h2_crypto_native import (
+    EXTRA_BTC_RET_KEY,
+    H2CryptoNative,
+)
+from src.l3_strategy.strategies.h3_cme_maintenance import H3CmeMaintenance
+
+
+def _state(
+    *,
+    ts: datetime,
+    regime: str = "R2_closure_weekend",
+    symbol: str = "xyz:SP500",
+    ipd: float = 0.0,
+    btc_ret_cum: float | None = None,
+) -> MarketState:
+    extras: dict = {}
+    if btc_ret_cum is not None:
+        extras[EXTRA_BTC_RET_KEY] = btc_ret_cum
+    return MarketState(
+        timestamp=ts,
+        symbol=symbol,
+        mid=100.0,
+        funding_rate=0.0001,
+        impact_bid=99.95,
+        impact_ask=100.05,
+        ipd=ipd,
+        regime=regime,
+        regime_uncertain=False,
+        extras=extras,
+    )
+
+
+def test_h2_long_when_btc_ret_high() -> None:
+    strat = H2CryptoNative(btc_ret_threshold=0.005)
+    base = datetime(2026, 5, 9, 12, tzinfo=UTC)
+    sig = strat.on_bar(_state(ts=base, btc_ret_cum=0.01))
+    assert sig is not None
+    assert sig.side == "long"
+
+
+def test_h2_short_when_btc_ret_low() -> None:
+    strat = H2CryptoNative(btc_ret_threshold=0.005)
+    base = datetime(2026, 5, 9, 12, tzinfo=UTC)
+    sig = strat.on_bar(_state(ts=base, btc_ret_cum=-0.02))
+    assert sig is not None
+    assert sig.side == "short"
+
+
+def test_h2_skips_active_regime() -> None:
+    strat = H2CryptoNative(btc_ret_threshold=0.005)
+    base = datetime(2026, 5, 5, 12, tzinfo=UTC)
+    sig = strat.on_bar(_state(ts=base, regime="R1_active", btc_ret_cum=0.05))
+    assert sig is None
+
+
+def test_h2_skips_when_no_btc_ret() -> None:
+    strat = H2CryptoNative()
+    sig = strat.on_bar(_state(ts=datetime(2026, 5, 9, 12, tzinfo=UTC)))
+    assert sig is None
+
+
+def test_h3_short_when_cum_ipd_positive_in_r3() -> None:
+    strat = H3CmeMaintenance(window=10, cum_ipd_entry_threshold=3.0)
+    base = datetime(2026, 5, 6, 22, tzinfo=UTC)  # ET 17-18 域
+    sig: Signal | None = None
+    for i in range(10):
+        sig = strat.on_bar(
+            _state(
+                ts=base + timedelta(seconds=i),
+                regime="R3_closure_daily",
+                ipd=1.0,
+            )
+        )
+    assert sig is not None
+    assert sig.side == "short"
+
+
+def test_h3_skips_outside_r3() -> None:
+    strat = H3CmeMaintenance(window=5, cum_ipd_entry_threshold=2.0)
+    base = datetime(2026, 5, 9, 12, tzinfo=UTC)
+    for i in range(10):
+        sig = strat.on_bar(
+            _state(
+                ts=base + timedelta(seconds=i),
+                regime="R2_closure_weekend",
+                ipd=1.0,
+            )
+        )
+    assert sig is None  # H3 は R3 のみ


### PR DESCRIPTION
## Summary
Phase 2 戦略 H2 / H3 の prototype 実装. 1週間 collect 後の実分布で backtest 完走を狙う.

## Linked Issues
- Closes #36 (H2)
- Closes #37 (H3)

## DoD
- [x] strategies/h2_crypto_native.py + h3_cme_maintenance.py
- [x] 43/43 tests pass (新規 6 tests)
- [x] ruff/format clean

## Notes
H2 の MarketState.extras['btc_ret_cum'] 注入は L2 pipeline 拡張 (別 PR) で対応.
現状は Strategy ABC に extras 渡しの土台があるので, 戦略本体は問題なく動作する.

🤖 Generated with [Claude Code](https://claude.com/claude-code)