### PR TITLE
release: v0.2.0 — Phase 2 tooling + LiveEngine dry-run (docs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # CHANGELOG
 
+## v0.2.0 — 2026-05-04 (Phase 2 tooling + LiveEngine dry-run)
+
+Phase 2 KPI ツール + 戦略 H2/H3 + LiveEngine dry-run まで完了. 1週間 collect 後に実分布で全 KPI を実行可能な状態.
+
+### Added
+- **Phase 2 KPI ツール (PR #40)**:
+  - src/l2_features/distribution.py: Hill 推定 + Shapiro-Wilk + Welch t-test
+  - scripts/kpi_fat_tail.py: regime 別ファットテール判定
+  - scripts/kpi_regime_diff_test.py: pairwise Welch t-test
+  - tests/test_distribution.py: 6 tests (Pareto/normal 判定確認済)
+- **戦略 H2 / H3 (PR #41)**:
+  - strategies/h2_crypto_native.py: closure 中の BTC リターン同方向ベット
+  - strategies/h3_cme_maintenance.py: CME メンテ時間 mini-closure mean reversion
+  - tests/test_h2_h3_strategies.py: 6 tests
+- **LiveEngine dry-run (PR #42)**:
+  - src/l3_strategy/live.py: BacktestEngine と同じ Strategy.on_bar を呼ぶ
+  - cli.py に live コマンド (h1 / h3 を選択して dry-run 起動)
+  - tests/test_live_engine.py: 3 tests
+  - 実発注は Phase 3 で別途対応 (EIP-712 hot wallet 等)
+
+### Tests
+- 46 / 46 pytest pass
+- ruff + format clean
+
+### Issues closed
+すべての Open Issues を close. 次フェーズ用の Issue は Phase 3 ブレストで起票.
+
 ## v0.1.0 — 2026-05-04 (Phase 1 完了)
 
 Phase 1 のコア骨格 + 実データ動作確認 + 全 KPI スクリプト実装. tag付きリリース.

--- a/README.md
+++ b/README.md
@@ -5,16 +5,18 @@
 Hyperliquid (HIP-3 / Trade[XYZ]) 上の **米株指数 perpetual** と **オールド金融 (CME e-mini, NYSE/NASDAQ)** の **Oracle 二重構造** をデータで観測し、**closure (週末・CMEメンテ・祝日) 中の HL 独自価格発見** に由来するアルファを統計的に検証する。
 
 ## ステータス
-**Phase 1 完了 (v0.1.0)** — 詳細は [`docs/phase-1-report.md`](docs/phase-1-report.md)
+**Phase 2 ツール完備 (v0.2.0)** — Phase 1 詳細: [`docs/phase-1-report.md`](docs/phase-1-report.md), 履歴: [CHANGELOG](CHANGELOG.md)
 
 - [x] Phase 0: HL 仕様調査 完了 (`docs/specs/2026-05-04-phase0-spec-notes.md`)
 - [x] v3 設計 確定 (`docs/specs/2026-05-04-v3-design.md`)
 - [x] L1 Data Ingestion (HIP-3 dex 対応, graceful shutdown, async I/O)
-- [x] L2 Feature Engineering (動的 calendar, cointegration, resilience)
+- [x] L2 Feature Engineering (動的 calendar, cointegration, resilience, **distribution / Hill 推定**)
 - [x] L3 Strategy / Backtest (Strategy ABC, マルチポジ engine, cost model)
-- [x] KPI K1/K2/K7/K8/K9 スクリプト + 実データ動作確認
-- [x] CI (ruff/format/mypy/pytest), 31/31 tests pass
-- [ ] Phase 2 (1週間 collect 後の実分布レポート + アルファ存在確認)
+- [x] **戦略 H1 + H2 + H3** prototype (mean reversion / Crypto Native / CMEメンテ)
+- [x] KPI K1/K2/K7/K8/K9 + **fat-tail / regime t-test** スクリプト
+- [x] **LiveEngine dry-run** (BacktestEngine と同一 Strategy ABC を継承)
+- [x] CI (ruff/format/mypy/pytest), **46/46 tests pass**
+- [ ] Phase 3 (実発注 + EIP-712 鍵管理 + キル スイッチ)
 
 ## アーキテクチャ
 3層メダリオン (詳細は [`docs/specs/2026-05-04-v3-design.md`](docs/specs/2026-05-04-v3-design.md) §4):


### PR DESCRIPTION
## Summary
docs/CHANGELOG/README を v0.2.0 状態に更新. 実コードは PR #40, #41, #42 で develop に merge 済み.
このPRが merge されたら develop → main の PR を作成し tag v0.2.0 を打つ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)