### PR TITLE
release: v0.3.0 — Analytics dashboard (marimo + altair)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,41 @@
 # CHANGELOG
 
+## v0.3.0 — 2026-05-04 (Analytics dashboard — marimo + altair)
+
+戦略 backtest と KPI を 1 画面で対話的に観測する **marimo ベース GUI** を導入.
+
+### Added
+- **`src/gui/` モジュール** (PR-B)
+  - `data_access.py`: DuckDB in-memory connection ラッパー + 安全な glob 読み込み
+  - `perf_metrics.py`: Sharpe (95% CI 付き) / Sortino / Max DD / Hit Rate / Profit Factor / Calmar / Expectancy / Equity curve / Underwater curve
+  - `charts.py`: altair 6.1.0 ベース (equity / underwater / trade pnl histogram / IPD time series / top-of-book)
+- **`notebooks/dashboard.py`** (PR-C)
+  - marimo 0.23.4 reactive notebook
+  - 上段: 戦略選択 + 銘柄選択 + Sharpe 等 8 標準 KPI + Equity/Underwater chart + Trade table + PnL ヒストグラム
+  - 中段: 既存 KPI (K1/K2/K7/K8/K9/fat_tail/regime_diff) のカード型サマリ
+  - 下段: 自由探索セル (IPD time series / top-of-book / DuckDB SQL)
+- **backtest 結果 Parquet 永続化** (PR-A)
+  - `src/l3_strategy/persistence.py`: `data/curated/backtest_results/{strategy}/{date}/{hour}/` に保存
+  - `cli.py backtest --save` (default True) で自動保存
+
+### Tests
+- 61 / 61 pytest pass
+- ruff / format clean
+- `marimo run --headless` で HTTP 200 起動確認
+
+### Usage
+```bash
+pip install -e ".[dev,gui]"   # marimo + altair をインストール
+python -m src.cli backtest h1 --symbol xyz:SP500   # backtest 実行 (Parquet 自動保存)
+marimo edit notebooks/dashboard.py                  # 編集モード
+marimo run notebooks/dashboard.py                   # 発表モード (read-only アプリ)
+```
+
+### 主要 PR (develop merge 済)
+- PR-A: backtest result Parquet 永続化
+- PR-B: src/gui/ implementation
+- PR-C: marimo notebook + docs
+
 ## v0.2.0 — 2026-05-04 (Phase 2 tooling + LiveEngine dry-run)
 
 Phase 2 KPI ツール + 戦略 H2/H3 + LiveEngine dry-run まで完了. 1週間 collect 後に実分布で全 KPI を実行可能な状態.

--- a/README.md
+++ b/README.md
@@ -5,18 +5,29 @@
 Hyperliquid (HIP-3 / Trade[XYZ]) 上の **米株指数 perpetual** と **オールド金融 (CME e-mini, NYSE/NASDAQ)** の **Oracle 二重構造** をデータで観測し、**closure (週末・CMEメンテ・祝日) 中の HL 独自価格発見** に由来するアルファを統計的に検証する。
 
 ## ステータス
-**Phase 2 ツール完備 (v0.2.0)** — Phase 1 詳細: [`docs/phase-1-report.md`](docs/phase-1-report.md), 履歴: [CHANGELOG](CHANGELOG.md)
+**Analytics dashboard 完備 (v0.3.0)** — Phase 1 詳細: [`docs/phase-1-report.md`](docs/phase-1-report.md), 履歴: [CHANGELOG](CHANGELOG.md)
 
 - [x] Phase 0: HL 仕様調査 完了 (`docs/specs/2026-05-04-phase0-spec-notes.md`)
 - [x] v3 設計 確定 (`docs/specs/2026-05-04-v3-design.md`)
 - [x] L1 Data Ingestion (HIP-3 dex 対応, graceful shutdown, async I/O)
 - [x] L2 Feature Engineering (動的 calendar, cointegration, resilience, **distribution / Hill 推定**)
-- [x] L3 Strategy / Backtest (Strategy ABC, マルチポジ engine, cost model)
+- [x] L3 Strategy / Backtest (Strategy ABC, マルチポジ engine, cost model, **Parquet 永続化**)
 - [x] **戦略 H1 + H2 + H3** prototype (mean reversion / Crypto Native / CMEメンテ)
 - [x] KPI K1/K2/K7/K8/K9 + **fat-tail / regime t-test** スクリプト
 - [x] **LiveEngine dry-run** (BacktestEngine と同一 Strategy ABC を継承)
-- [x] CI (ruff/format/mypy/pytest), **46/46 tests pass**
+- [x] **Analytics dashboard** (marimo + altair, Sharpe/Sortino/DD 等 8 KPI + KPI カード + 自由探索)
+- [x] CI (ruff/format/mypy/pytest), **61/61 tests pass**
 - [ ] Phase 3 (実発注 + EIP-712 鍵管理 + キル スイッチ)
+
+## Quick start (analytics dashboard)
+```bash
+pip install -e ".[dev,gui]"
+python -m src.cli collect                              # L1 (Ctrl-C で停止)
+python -m src.cli features                             # L2
+python -m src.cli backtest h1 --symbol xyz:SP500       # L3 (Parquet 自動保存)
+marimo edit notebooks/dashboard.py                     # GUI (編集)
+marimo run  notebooks/dashboard.py                     # GUI (発表)
+```
 
 ## アーキテクチャ
 3層メダリオン (詳細は [`docs/specs/2026-05-04-v3-design.md`](docs/specs/2026-05-04-v3-design.md) §4):

--- a/docs/specs/2026-05-04-gui-design.md
+++ b/docs/specs/2026-05-04-gui-design.md
@@ -1,0 +1,330 @@
+# GUI Design — Phase 1.5 analytics dashboard (marimo + altair + DuckDB)
+
+作成日: 2026-05-04
+バージョン: v1.0 (確定)
+状態: 設計確定, 実装着手可
+
+---
+
+## 0. ビジョン
+
+取得済み Parquet データ (L1 raw + L2 curated + KPI json) を **対話的に可視化・分析** する GUI を [marimo](https://marimo.io) で構築する.
+
+v3 design §0.2 「**大数上優位**」「**真の貢献**」の検証ツールとして, 戦略 (H1/H2/H3) のパフォーマンス指標 (Sharpe / Sortino / Max DD ほか) と既存 KPI (K1〜K9 + fat-tail + regime t-test) を1画面で確認できる状態にする.
+
+---
+
+## 1. 要件
+
+### 1.1 利用シーン (確定)
+- **C: 探索 + ダッシュボード兼用** — 上段は固定ダッシュボード (戦略 KPI 8指標 + KPI カード), 下段は自由探索セル
+- 1ファイルで両用 (`marimo edit` 探索モード / `marimo run` 発表モード)
+
+### 1.2 必須パフォーマンス指標 (確定: 標準8指標)
+| 指標 | 表示形式 |
+|---|---|
+| Sharpe (annualized) | 数値 + 95% CI |
+| Sortino | 数値 |
+| Max Drawdown | 数値 + Underwater curve |
+| Hit Rate | パーセンテージ |
+| Profit Factor | 数値 |
+| Expectancy bps | 既存 backtest 出力を流用 |
+| Equity curve | 累積 P/L 時系列 |
+| Trade Table | 個別取引 (entry/exit/symbol/PnL) ソート可 |
+
+加えて以下を補助表示:
+- Calmar (Max DD と等価情報だが算出簡単なので併記)
+- Regime breakdown (regime 別 Sharpe / Hit / Expectancy)
+- Capacity 試算 (K9 連動)
+
+### 1.3 データソース (確定)
+**B: DuckDB クエリレイヤー**.
+- 既存 `src/l2_features/loader.py` が DuckDB 利用済み, パイプライン統一
+- marimo セルから `con.execute("SELECT ...").pl()` で SQL 直書き → 自由探索パートでアドホック分析しやすい
+- 起動時に in-memory DB へ Parquet を attach
+
+### 1.4 リアクティブ性
+- ウィジェット (戦略 dropdown / 銘柄 dropdown / 期間 slider / regime checkbox) の値が変わると依存セルが自動再評価
+- ファイル更新は手動 reload (Phase 1.5 では十分)
+- 将来 file watcher / SurrealDB 経由のライブ更新を別フェーズで検討
+
+---
+
+## 2. アーキテクチャ
+
+```
+┌──────────────────────────────────────────────┐
+│  notebooks/dashboard.py (marimo notebook)    │
+│  - reactive cells                             │
+│  - 上段: 固定ダッシュボード                    │
+│  - 中段: KPI カードビュー                      │
+│  - 下段: 自由探索セル                          │
+└────────────────────┬─────────────────────────┘
+                     │ DuckDB con (in-memory)
+                     ↓
+   ┌─────────────────┴─────────────────┐
+   │  src/gui/  (新規)                  │
+   │  - data_access.py: DuckDB ラッパー │
+   │  - perf_metrics.py: Sharpe / DD…  │
+   │  - charts.py: altair チャート関数 │
+   └─────────────────┬─────────────────┘
+                     ↓
+       data/raw/*.parquet
+       data/curated/*.parquet (features, backtest_results)
+       docs/kpi/*.json
+```
+
+### 2.1 marimo を採用する理由
+- **reactive**: ウィジェット値変更 → 依存セル自動再評価. Streamlit の rerun 全体実行と違い細粒度
+- **Pure Python file**: git-friendly (Jupyter ipynb のメタデータ汚染なし)
+- **2モード共用**: `marimo edit` (探索) と `marimo run` (アプリ) を 1 ファイルで切替
+- **WASM export 可**: 将来 GitHub Pages デプロイ可
+- **SQL cell built-in**: `marimo[recommended]` で SQL セル直接サポート
+
+### 2.2 altair を採用する理由
+- marimo 公式推奨 (`mo.ui.altair_chart()` で統合)
+- declarative syntax で短い
+- 軽量 (依存は narwhals + jsonschema + jinja2)
+- インタラクティブ (zoom/pan/tooltip) 標準装備
+- vegafusion で大データ対応も可能 (Phase 2 以降)
+
+---
+
+## 3. 画面構成
+
+### 3.1 ヘッダ + グローバル controls
+```
+[戦略 ▾ H1] [銘柄 ▾ xyz:SP500] [期間 ━━━━━]
+[regime: ☑R1 ☑R2 ☑R3 ☑R4]
+```
+
+### 3.2 上段: 固定パフォーマンスダッシュボード
+```
+┌─ Performance summary (戦略×銘柄×期間) ─────┐
+│ Sharpe: 1.2 (95% CI [0.4, 2.0])              │
+│ Sortino: 1.8                                 │
+│ Profit Factor: 1.6                           │
+│ Hit Rate: 58%                                │
+│ Expectancy: +12.3 bps                        │
+│ Max DD: -3.2%   Calmar: 0.4                  │
+└──────────────────────────────────────────────┘
+┌─ Equity curve (cumulative net P/L) ─────────┐
+│ [altair line chart, regime 帯で色分け]       │
+└──────────────────────────────────────────────┘
+┌─ Underwater curve (drawdown over time) ─────┐
+│ [filled area chart, max DD ハイライト]       │
+└──────────────────────────────────────────────┘
+┌─ Regime breakdown (table) ──────────────────┐
+│ regime  | n  | sharpe | hit% | expectancy   │
+│ R1      | 12 | 0.8    | 50%  | +5 bps       │
+│ R2      | 30 | 1.5    | 60%  | +18 bps      │
+└──────────────────────────────────────────────┘
+┌─ Trade table (sortable) ────────────────────┐
+│ entry_ts | exit_ts | sym | side | pnl_bps   │
+└──────────────────────────────────────────────┘
+```
+
+### 3.3 中段: KPI カード
+docs/kpi/*.json をカード化. クリックで md 詳細展開:
+```
+┌─[K1]─────┐ ┌─[K2]─────┐ ┌─[K7]─────┐
+│ closure  │ │ warp gap │ │ CME maint│
+│ IPD drift│ │ at open  │ │ IPD      │
+│ N=1 ⚠    │ │ N=0 ⚠    │ │ N=0 ⚠    │
+└──────────┘ └──────────┘ └──────────┘
+┌─[K8]─────┐ ┌─[K9]─────┐ ┌─[fat]────┐ ┌─[regime]─┐
+│ BTC corr │ │ Capacity │ │ tail     │ │ Welch t  │
+│ closure  │ │ p95 SP500│ │ Hill α   │ │ pairwise │
+│          │ │ =199s ⚠  │ │          │ │          │
+└──────────┘ └──────────┘ └──────────┘ └──────────┘
+```
+
+### 3.4 下段: 自由探索セル
+- 空セル + サンプル query (`con.execute("SELECT ... ").pl()`)
+- IPD 時系列プロット (銘柄選択)
+- 板スナップショット heatmap (時刻選択)
+- Cointegration spread の z-score プロット
+- マークダウンセルでメモ
+
+---
+
+## 4. パフォーマンス指標の実装 (`src/gui/perf_metrics.py`)
+
+```python
+@dataclass
+class PerfStats:
+    n_trades: int
+    total_pnl_usd: float
+    sharpe_annualized: float
+    sharpe_ci_low: float
+    sharpe_ci_high: float
+    sortino: float
+    calmar: float
+    max_drawdown_pct: float
+    hit_rate: float
+    profit_factor: float
+    expectancy_bps: float
+
+def compute_perf_stats(
+    trades: list[FilledTrade],
+    periods_per_year: int | None = None,
+) -> PerfStats: ...
+
+def equity_curve(trades) -> pl.DataFrame:    # ts, cumulative_pnl_usd
+def underwater_curve(trades) -> pl.DataFrame:  # ts, drawdown_pct
+```
+
+### 4.1 Sharpe の年率化
+取引頻度が時間軸で不均一なので, 「**1取引あたり** の bps 平均と σ」を 「**年間試行回数 N**」で年率換算:
+
+```
+mean_annual = mean_bps × N
+std_annual  = std_bps × sqrt(N)
+sharpe      = mean_annual / std_annual = mean_bps / std_bps × sqrt(N)
+```
+
+`N` は v3 採否基準 K11 (年間試行回数推定) と整合させる.
+
+### 4.2 Sortino
+下方リスクのみで除す:
+```
+downside_returns = [r for r in returns if r < 0]
+downside_std = std(downside_returns)
+sortino = mean / downside_std × sqrt(N)
+```
+
+### 4.3 Max Drawdown
+```
+cum = cumsum(pnl)
+running_max = cum.cummax()
+drawdown = (cum - running_max) / running_max
+max_dd = drawdown.min()  # 負値
+```
+
+### 4.4 Hit Rate / Profit Factor
+- Hit Rate = wins / n_trades
+- Profit Factor = sum(wins) / |sum(losses)|
+
+### 4.5 Sharpe 95% CI
+標準誤差 = `sqrt((1 + sharpe^2 / 2) / n)` (大標本近似).
+95% CI = `sharpe ± 1.96 × se`.
+
+---
+
+## 5. 図表ライブラリ (altair)
+
+```python
+def equity_curve_chart(df: pl.DataFrame) -> alt.Chart: ...
+def underwater_chart(df: pl.DataFrame) -> alt.Chart: ...
+def regime_breakdown_table(df: pl.DataFrame) -> alt.Chart: ...
+def ipd_time_series(df: pl.DataFrame, symbol: str) -> alt.Chart: ...
+def book_snapshot_heatmap(df: pl.DataFrame, ts) -> alt.Chart: ...
+```
+
+すべて `mo.ui.altair_chart()` で marimo 統合可. インタラクティブ操作で表示範囲変更.
+
+---
+
+## 6. ディレクトリ構成
+
+```
+diff-old-new/
+├── notebooks/
+│   └── dashboard.py          ← marimo notebook (1ファイル GUI)
+├── src/
+│   └── gui/                  ← 新規モジュール
+│       ├── __init__.py
+│       ├── data_access.py    ← DuckDB con + 主要 SQL
+│       ├── perf_metrics.py   ← Sharpe / Sortino / DD など
+│       └── charts.py         ← altair チャート関数
+├── tests/
+│   └── test_perf_metrics.py  ← 数値テスト
+└── pyproject.toml             ← marimo + altair を notebook extra に追加
+```
+
+---
+
+## 7. backtest 結果の永続化 (前提条件 / PR-A)
+
+現状 `BacktestResult.trades` は CLI の print のみ → GUI で読めない. 小さな修正:
+
+- `src/cli.py` の `backtest` コマンドで `BacktestResult` を Parquet 出力
+- パス: `data/curated/backtest_results/{strategy}/{run_id}.parquet`
+- カラム: trades 各属性 + run metadata (strategy / symbol / cost params / timestamp)
+- GUI はこの Parquet を読む
+
+PR-A としてGUI 実装の前に1度入れる.
+
+---
+
+## 8. 依存追加 (`pyproject.toml`)
+
+```toml
+[project.optional-dependencies]
+notebook = [
+    "marimo[recommended]~=0.23.4",
+    "altair~=6.1.0",
+    # vegafusion は大データ集計時のみ必要 (Phase 2 で追加)
+]
+```
+
+最新版は実装着手時に PyPI で再確認 (依存解決 conflict があれば調整).
+
+---
+
+## 9. テスト
+
+- `tests/test_perf_metrics.py`: Sharpe / DD / Hit Rate を手計算と照合 (合成 trades)
+  - 既知の trade 列 → 期待 Sharpe / DD を hardcode して検証
+  - property: trades が空なら全指標 0.0 (no error)
+  - property: trades 全勝なら Profit Factor = inf, Hit Rate = 1.0
+- marimo notebook 自体は **smoke test のみ** (GUI なので): `marimo run --headless notebooks/dashboard.py` でエラー無く起動
+- altair チャート関数: 戻り値が `alt.Chart` インスタンスかをチェック
+
+---
+
+## 10. PR 段取り
+
+1. **PR-A**: backtest Parquet 永続化 (前提)
+   - `src/cli.py`, `src/l3_strategy/backtest.py` 修正
+   - 既存 H1 backtest を実行して Parquet が出ることを確認
+2. **PR-B**: `src/gui/` 実装 + tests
+   - data_access / perf_metrics / charts
+   - 全ロジックに unit test
+3. **PR-C**: `notebooks/dashboard.py` + 依存追加 + docs
+   - marimo notebook
+   - CHANGELOG / README に GUI セクション
+   - `marimo run --headless` の smoke test を CI に追加
+
+3 PR を別タグ (**v0.3.0**) にまとめてリリース.
+
+---
+
+## 11. Definition of Done
+
+- [ ] PR-A merged: backtest 結果が Parquet に保存される
+- [ ] PR-B merged: `src/gui/` の全関数に test, ruff/format/pytest pass
+- [ ] PR-C merged: `notebooks/dashboard.py` で全 8 KPI 表示 + KPI カード + 探索セル
+- [ ] `marimo edit notebooks/dashboard.py` で起動確認 (実データで動く)
+- [ ] CHANGELOG / README に GUI セクション追加
+- [ ] tag v0.3.0 + GitHub Release
+- [ ] CI green
+
+---
+
+## 12. 将来拡張 (本リリース外)
+
+- file watcher / polling 経由のライブ更新 (collect 稼働中の自動更新)
+- WASM export → GitHub Pages デプロイ
+- SurrealDB バックエンド (knowledge / output_log と連携)
+- vegafusion 統合 (大データ集計)
+- Bayesian backtest (uncertainty quantification)
+- Parameter sweep grid view (戦略パラメータのヒートマップ)
+
+---
+
+## 13. 参照
+- [marimo docs](https://docs.marimo.io)
+- [altair docs](https://altair-viz.github.io)
+- [v3 design](2026-05-04-v3-design.md) §0.2 (大数上優位の定義)
+- [phase 1 report](../phase-1-report.md)

--- a/notebooks/dashboard.py
+++ b/notebooks/dashboard.py
@@ -1,0 +1,323 @@
+"""diff-old-new analytics dashboard (marimo).
+
+使い方:
+    marimo edit notebooks/dashboard.py    # 編集 (探索モード)
+    marimo run notebooks/dashboard.py     # 発表 (read-only アプリ)
+
+設計: docs/specs/2026-05-04-gui-design.md
+"""
+
+import marimo
+
+__generated_with = "0.23.4"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _imports():
+    import sys
+    from pathlib import Path
+
+    # ensure project src on path when notebook is run from notebooks/
+    repo_root = Path(__file__).resolve().parent.parent
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+
+    import marimo as mo
+    import polars as pl
+
+    from src.config import load_config
+    from src.gui.charts import (
+        book_top_depth_chart,
+        equity_curve_chart,
+        ipd_time_series_chart,
+        trade_pnl_histogram,
+        underwater_chart,
+    )
+    from src.gui.data_access import GuiDataSource
+    from src.gui.perf_metrics import (
+        compute_perf_stats,
+        equity_curve,
+        underwater_curve,
+    )
+
+    return (
+        mo,
+        pl,
+        load_config,
+        GuiDataSource,
+        compute_perf_stats,
+        equity_curve,
+        underwater_curve,
+        equity_curve_chart,
+        underwater_chart,
+        trade_pnl_histogram,
+        ipd_time_series_chart,
+        book_top_depth_chart,
+        repo_root,
+    )
+
+
+@app.cell
+def _header(mo):
+    mo.md(
+        "# diff-old-new — analytics dashboard\n\n"
+        "Hyperliquid HIP-3 (Trade[XYZ]) 米株 perp の **Oracle 二重構造** を活用する戦略の\n"
+        "パフォーマンスを観測するダッシュボード.\n\n"
+        "- 上段: 戦略 backtest の **8 標準 KPI** (Sharpe / Sortino / Max DD / Hit / PF / "
+        "Expectancy + Equity / Underwater curve + Trade table)\n"
+        "- 中段: 既存 KPI (K1/K2/K7/K8/K9/fat_tail/regime_diff) のサマリ\n"
+        "- 下段: 自由探索セル (DuckDB SQL + 任意の図表)\n\n"
+        "詳細: `docs/specs/2026-05-04-gui-design.md` / `docs/phase-1-report.md`"
+    )
+    return
+
+
+@app.cell
+def _data_source(load_config, GuiDataSource, repo_root):
+    cfg = load_config(
+        [
+            repo_root / "config" / "default.yaml",
+            repo_root / "config" / "local.yaml",
+        ]
+    )
+    ds = GuiDataSource.from_config(cfg.storage, kpi_dir=repo_root / "docs" / "kpi")
+    return cfg, ds
+
+
+@app.cell
+def _controls(mo, ds):
+    strategies = ds.list_backtest_strategies() or ["(no backtest results yet)"]
+    symbols = ds.list_symbols() or ["(no data yet)"]
+
+    strategy_select = mo.ui.dropdown(
+        options=strategies,
+        value=strategies[0],
+        label="Strategy",
+    )
+    symbol_select = mo.ui.dropdown(
+        options=["(all)", *symbols],
+        value="(all)",
+        label="Symbol filter",
+    )
+    mo.hstack([strategy_select, symbol_select])
+    return strategy_select, symbol_select
+
+
+@app.cell
+def _load_trades(ds, strategy_select, symbol_select):
+    strategy = strategy_select.value
+    symbol = None if symbol_select.value == "(all)" else symbol_select.value
+    if strategy.startswith("(no"):
+        trades = None
+    else:
+        trades = ds.load_backtest_trades(strategy, symbol=symbol)
+        if trades is not None and trades.is_empty():
+            trades = None
+    return trades, strategy, symbol
+
+
+@app.cell
+def _perf_summary(mo, trades, compute_perf_stats):
+    if trades is None:
+        ps = None
+        _summary_md = mo.md(
+            "> ⚠ **No backtest results found**.\n"
+            "> 先に CLI で backtest を実行してください:\n"
+            "> ```bash\n"
+            "> python -m src.cli backtest h1 --symbol xyz:SP500\n"
+            "> ```"
+        )
+    else:
+        ps = compute_perf_stats(trades)
+        win_pct = f"{ps.hit_rate * 100:.1f}%"
+        pf = "∞" if ps.profit_factor == float("inf") else f"{ps.profit_factor:.2f}"
+        _summary_md = mo.md(
+            f"## Performance summary\n\n"
+            f"| metric | value |\n"
+            f"|---|---|\n"
+            f"| **N trades** | {ps.n_trades} |\n"
+            f"| **Total net P/L (USD)** | {ps.total_pnl_usd:+.2f} |\n"
+            f"| **Sharpe (annualized)** | **{ps.sharpe_annualized:+.2f}** &nbsp; "
+            f"95% CI [{ps.sharpe_ci_low:+.2f}, {ps.sharpe_ci_high:+.2f}] |\n"
+            f"| **Sortino (annualized)** | {ps.sortino_annualized:+.2f} |\n"
+            f"| **Max Drawdown** | {ps.max_drawdown_pct:.2%} |\n"
+            f"| **Calmar** | {ps.calmar:+.2f} |\n"
+            f"| **Hit rate** | {win_pct} |\n"
+            f"| **Profit factor** | {pf} |\n"
+            f"| **Expectancy (bps/trade)** | {ps.expectancy_bps:+.2f} |\n"
+            f"| **σ (bps/trade)** | {ps.std_bps:.2f} |"
+        )
+    _summary_md
+    return (ps,)
+
+
+@app.cell
+def _equity_chart(mo, trades, equity_curve, equity_curve_chart):
+    if trades is None:
+        mo.md("")
+        chart_eq = None
+    else:
+        eq = equity_curve(trades)
+        chart_eq = mo.ui.altair_chart(equity_curve_chart(eq))
+    chart_eq if chart_eq is not None else mo.md("")
+    return (chart_eq,)
+
+
+@app.cell
+def _underwater_chart(mo, trades, underwater_curve, underwater_chart):
+    if trades is None:
+        mo.md("")
+        chart_uw = None
+    else:
+        uw = underwater_curve(trades)
+        chart_uw = mo.ui.altair_chart(underwater_chart(uw))
+    chart_uw if chart_uw is not None else mo.md("")
+    return (chart_uw,)
+
+
+@app.cell
+def _trade_histogram(mo, trades, trade_pnl_histogram):
+    if trades is None:
+        mo.md("")
+        hist = None
+    else:
+        hist = mo.ui.altair_chart(trade_pnl_histogram(trades))
+    hist if hist is not None else mo.md("")
+    return (hist,)
+
+
+@app.cell
+def _trade_table(mo, trades):
+    if trades is None:
+        mo.md("")
+        table = None
+    else:
+        cols = [
+            "entry_ts",
+            "exit_ts",
+            "symbol",
+            "side",
+            "size_usd",
+            "entry_px",
+            "exit_px",
+            "net_pnl_usd",
+            "net_bps",
+            "holding_minutes",
+        ]
+        avail = [c for c in cols if c in trades.columns]
+        table = mo.ui.table(
+            trades.select(avail).sort("entry_ts", descending=True).head(200),
+            label="Recent 200 trades (sortable)",
+        )
+    table if table is not None else mo.md("")
+    return (table,)
+
+
+@app.cell
+def _kpi_cards(mo, ds):
+    kpi_names = ["K1", "K2", "K7", "K8", "K9", "fat_tail", "regime_diff"]
+    cards = []
+    for name in kpi_names:
+        data = ds.load_kpi_json(name)
+        if not data:
+            cards.append(
+                mo.md(f"### {name}\n\n_no data yet_").style(
+                    {
+                        "min-width": "200px",
+                        "padding": "8px",
+                        "border": "1px solid #ccc",
+                        "border-radius": "8px",
+                    }
+                )
+            )
+            continue
+        # 短いサマリ表示
+        summary_lines: list[str] = []
+        if "warning" in data:
+            summary_lines.append(f"⚠ {data['warning']}")
+        if "n_total_bars" in data:
+            summary_lines.append(f"bars: {data['n_total_bars']}")
+        if "n_segments" in data:
+            summary_lines.append(f"segments: {data['n_segments']}")
+        if "n_total_events" in data:
+            summary_lines.append(f"events: {data['n_total_events']}")
+        if "by_symbol" in data:
+            for sym, stat in data["by_symbol"].items():
+                if isinstance(stat, dict) and "n_events" in stat:
+                    rate = stat.get("recovery_rate", 0)
+                    p95 = stat.get("recovery_sec_distribution", {}).get("p95", "-")
+                    p95s = f"{p95:.1f}s" if isinstance(p95, (int, float)) else str(p95)
+                    summary_lines.append(
+                        f"{sym}: n={stat['n_events']} rate={rate * 100:.0f}% p95={p95s}"
+                    )
+        body = "\n\n".join(summary_lines) if summary_lines else "(see md)"
+        cards.append(
+            mo.md(f"### {name}\n\n{body}").style(
+                {
+                    "min-width": "240px",
+                    "padding": "8px",
+                    "border": "1px solid #ccc",
+                    "border-radius": "8px",
+                }
+            )
+        )
+    mo.hstack(cards, wrap=True, gap=0.5)
+    return
+
+
+@app.cell
+def _exploration_header(mo):
+    mo.md(
+        "---\n\n"
+        "## 自由探索\n\n"
+        "以下のセルを編集して任意の分析を実行できる. `con = ds.con` を使えば DuckDB SQL で\n"
+        "Parquet を直接 query できる."
+    )
+    return
+
+
+@app.cell
+def _explore_ipd(mo, ds, symbol_select, ipd_time_series_chart):
+    sym_for_ipd = symbol_select.value if symbol_select.value != "(all)" else "xyz:SP500"
+    features = ds.load_features(sym_for_ipd)
+    if features.is_empty():
+        mo.md("_no features for ipd plot yet_")
+        ipd_chart = None
+    else:
+        ipd_chart = mo.ui.altair_chart(ipd_time_series_chart(features, sym_for_ipd))
+    ipd_chart if ipd_chart is not None else mo.md("_(empty)_")
+    return (ipd_chart,)
+
+
+@app.cell
+def _explore_book(mo, ds, symbol_select, book_top_depth_chart):
+    sym_for_book = symbol_select.value if symbol_select.value != "(all)" else "xyz:SP500"
+    l2 = ds.load_l2book(sym_for_book)
+    if l2.is_empty():
+        mo.md("_no l2book for top-of-book chart yet_")
+        book_chart = None
+    else:
+        book_chart = mo.ui.altair_chart(book_top_depth_chart(l2, sym_for_book))
+    book_chart if book_chart is not None else mo.md("_(empty)_")
+    return (book_chart,)
+
+
+@app.cell
+def _explore_sql(mo, ds):
+    _ = ds  # marimo dependency tracking 用 (con を変えたら再評価する想定)
+    mo.md(
+        "### DuckDB SQL 探索\n\n"
+        "`ds.con` で SQL を直接実行できる. 例:\n\n"
+        "```python\n"
+        "df = ds.con.execute(\n"
+        "    \"SELECT symbol, COUNT(*) FROM read_parquet('data/raw/l2book/**/*.parquet', union_by_name=true) GROUP BY symbol\"\n"
+        ").pl()\n"
+        "df\n"
+        "```"
+    )
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,10 +48,12 @@ dev = [
     "ruff~=0.15.12",
     "mypy~=1.20.2",
 ]
-notebook = [
-    "jupyter>=1.1.0",
-    "matplotlib>=3.9.0",
-    "seaborn>=0.13.0",
+gui = [
+    # marimo: reactive Python notebook (Jupyter 代替, git-friendly, app/edit 兼用)
+    "marimo[recommended]~=0.23.4",
+    # altair: declarative visualization
+    "altair~=6.1.0",
+    "pandas>=2.0",  # altair は pandas DataFrame を要求
 ]
 
 [project.scripts]
@@ -67,6 +69,8 @@ packages = ["src"]
 [tool.ruff]
 line-length = 100
 target-version = "py312"
+# marimo notebook は dependency injection 引数 (大文字 dataclass や useless expression 表現) を多用するため除外
+extend-exclude = ["notebooks/"]
 
 [tool.ruff.lint]
 select = [

--- a/src/cli.py
+++ b/src/cli.py
@@ -49,17 +49,18 @@ def features(
 
 @app.command()
 def backtest(
-    strategy: str = typer.Argument("h1", help="strategy id"),
-    symbol: str = typer.Option("SP500", help="対象 symbol"),
+    strategy: str = typer.Argument("h1", help="strategy id (h1/h3)"),
+    symbol: str = typer.Option("xyz:SP500", help="対象 symbol"),
     day: str | None = typer.Option(None, help="ISO date"),
     exit_min: int = typer.Option(60, help="exit_after_minutes"),
+    save: bool = typer.Option(True, help="data/curated/backtest_results/ に Parquet 保存"),
 ) -> None:
-    """L3: 指定戦略を curated features に対して backtest."""
+    """L3: 指定戦略を curated features に対して backtest. 結果は GUI が読める形式で保存."""
     from src.l2_features.loader import load_features
     from src.l3_strategy.backtest import BacktestEngine
-    from src.l3_strategy.strategies.h1_closure_mean_rev import (
-        H1ClosureMeanReversion,
-    )
+    from src.l3_strategy.persistence import save_backtest_result
+    from src.l3_strategy.strategies.h1_closure_mean_rev import H1ClosureMeanReversion
+    from src.l3_strategy.strategies.h3_cme_maintenance import H3CmeMaintenance
 
     cfg = _load()
     parsed = date_t.fromisoformat(day) if day else None
@@ -68,6 +69,8 @@ def backtest(
 
     if strategy == "h1":
         strat = H1ClosureMeanReversion()
+    elif strategy == "h3":
+        strat = H3CmeMaintenance()
     else:
         raise typer.BadParameter(f"Unknown strategy: {strategy}")
 
@@ -83,7 +86,6 @@ def backtest(
         f"win_rate={result.win_rate * 100:.1f}%"
     )
     if result.n_trades >= 30:
-        # CLT 95% 信頼区間
         ci_low = result.mean_net_bps - 1.96 * result.se_bps
         ci_high = result.mean_net_bps + 1.96 * result.se_bps
         print(f"95% CI: [{ci_low:+.2f}, {ci_high:+.2f}] bps")
@@ -91,6 +93,18 @@ def backtest(
             print("[OK] コスト控除後期待値が95%信頼区間で正 (LLN/CLT 採否判定)")
         else:
             print("[NG] サンプル不足 or エッジ未確認")
+
+    if save and result.n_trades > 0:
+        out_path = save_backtest_result(
+            result,
+            cfg.storage,
+            symbol_filter=symbol,
+            exit_after_minutes=exit_min,
+            taker_fee_rate=cfg.cost.taker_fee_rate,
+            funding_multiplier=cfg.cost.funding_multiplier,
+        )
+        if out_path:
+            print(f"[saved] {out_path}")
 
 
 @app.command()

--- a/src/gui/__init__.py
+++ b/src/gui/__init__.py
@@ -1,0 +1,5 @@
+"""GUI 用ロジック (data access + perf metrics + charts).
+
+notebooks/dashboard.py が import する. marimo / altair 自体には依存せず,
+data_access は DuckDB + Polars, perf_metrics は純粋数値計算, charts は altair.
+"""

--- a/src/gui/charts.py
+++ b/src/gui/charts.py
@@ -1,0 +1,133 @@
+"""altair チャート関数集.
+
+GUI dashboard が呼ぶ. 戻り値は altair.Chart で marimo の mo.ui.altair_chart() に渡す.
+"""
+
+from __future__ import annotations
+
+import altair as alt
+import polars as pl
+
+
+def equity_curve_chart(
+    df: pl.DataFrame,
+    *,
+    width: int = 700,
+    height: int = 240,
+) -> alt.Chart:
+    """累積 P/L (USD) 時系列."""
+    if df.is_empty():
+        df = pl.DataFrame({"ts": [], "cum_pnl_usd": []})
+    return (
+        alt.Chart(df.to_pandas())
+        .mark_line(color="#1f77b4")
+        .encode(
+            x=alt.X("ts:T", title="time"),
+            y=alt.Y("cum_pnl_usd:Q", title="cumulative net P/L (USD)"),
+            tooltip=["ts:T", "cum_pnl_usd:Q"],
+        )
+        .properties(width=width, height=height, title="Equity curve")
+        .interactive()
+    )
+
+
+def underwater_chart(
+    df: pl.DataFrame,
+    *,
+    width: int = 700,
+    height: int = 180,
+) -> alt.Chart:
+    """drawdown 時系列 (負値の area chart)."""
+    if df.is_empty():
+        df = pl.DataFrame({"ts": [], "drawdown_pct": []})
+    return (
+        alt.Chart(df.to_pandas())
+        .mark_area(color="#d62728", opacity=0.5)
+        .encode(
+            x=alt.X("ts:T", title="time"),
+            y=alt.Y(
+                "drawdown_pct:Q",
+                title="drawdown (fraction)",
+                axis=alt.Axis(format=".1%"),
+            ),
+            tooltip=["ts:T", alt.Tooltip("drawdown_pct:Q", format=".2%")],
+        )
+        .properties(width=width, height=height, title="Underwater curve")
+        .interactive()
+    )
+
+
+def trade_pnl_histogram(
+    trades: pl.DataFrame,
+    *,
+    width: int = 500,
+    height: int = 200,
+    column: str = "net_bps",
+) -> alt.Chart:
+    """trade 単位 P/L (bps) のヒストグラム."""
+    if trades.is_empty() or column not in trades.columns:
+        return alt.Chart(pl.DataFrame({column: []}).to_pandas()).mark_bar()
+    return (
+        alt.Chart(trades.select(column).to_pandas())
+        .mark_bar()
+        .encode(
+            x=alt.X(f"{column}:Q", bin=alt.Bin(maxbins=40), title=column),
+            y=alt.Y("count():Q", title="count"),
+            tooltip=[alt.Tooltip("count():Q", title="trades")],
+        )
+        .properties(width=width, height=height, title=f"{column} distribution")
+    )
+
+
+def ipd_time_series_chart(
+    features: pl.DataFrame,
+    symbol: str,
+    *,
+    width: int = 700,
+    height: int = 200,
+) -> alt.Chart:
+    """L2 features の IPD 時系列を 1 銘柄でプロット (regime 色分け)."""
+    if features.is_empty() or "ipd" not in features.columns:
+        return alt.Chart(pl.DataFrame({"exchange_ts": [], "ipd": []}).to_pandas())
+    sub = features.filter(pl.col("symbol") == symbol).select(["exchange_ts", "ipd", "regime"])
+    return (
+        alt.Chart(sub.to_pandas())
+        .mark_line(opacity=0.7)
+        .encode(
+            x=alt.X("exchange_ts:T", title="time"),
+            y=alt.Y("ipd:Q", title="IPD"),
+            color=alt.Color("regime:N", title="regime"),
+            tooltip=["exchange_ts:T", "ipd:Q", "regime:N"],
+        )
+        .properties(width=width, height=height, title=f"IPD time series — {symbol}")
+        .interactive()
+    )
+
+
+def book_top_depth_chart(
+    l2book: pl.DataFrame,
+    symbol: str,
+    *,
+    width: int = 700,
+    height: int = 200,
+) -> alt.Chart:
+    """top-of-book best_bid / best_ask の時系列."""
+    if l2book.is_empty():
+        return alt.Chart(pl.DataFrame({"exchange_ts": [], "best_bid": []}).to_pandas())
+    sub = (
+        l2book.filter(pl.col("symbol") == symbol)
+        .select(["exchange_ts", "best_bid", "best_ask"])
+        .melt(id_vars="exchange_ts", value_name="px", variable_name="side")
+    )
+    return (
+        alt.Chart(sub.to_pandas())
+        .mark_line()
+        .encode(
+            x=alt.X("exchange_ts:T", title="time"),
+            y=alt.Y("px:Q", title="price"),
+            color="side:N",
+            tooltip=["exchange_ts:T", "px:Q", "side:N"],
+        )
+        .properties(width=width, height=height, title=f"top-of-book — {symbol}")
+        .interactive()
+    )

--- a/src/gui/data_access.py
+++ b/src/gui/data_access.py
@@ -1,0 +1,122 @@
+"""GUI から見たデータアクセス層 (DuckDB ラッパー).
+
+src/l2_features/loader.py が L2 pipeline 内で使っているのと同じ DuckDB を,
+GUI 用に共通化. notebook 1個に対して 1 connection.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import duckdb
+import polars as pl
+
+from src.config import StorageConfig
+
+
+@dataclass
+class GuiDataSource:
+    """marimo notebook が抱える DuckDB connection と各 glob.
+
+    使い方:
+        ds = GuiDataSource.from_config(cfg.storage)
+        df = ds.load_backtest_trades("H1_closure_mean_rev")
+    """
+
+    raw_root: Path
+    curated_root: Path
+    kpi_dir: Path
+    con: duckdb.DuckDBPyConnection
+
+    @classmethod
+    def from_config(cls, storage: StorageConfig, kpi_dir: Path | None = None) -> GuiDataSource:
+        return cls(
+            raw_root=storage.raw_data_root,
+            curated_root=storage.curated_data_root,
+            kpi_dir=kpi_dir or Path("docs/kpi"),
+            con=duckdb.connect(":memory:"),
+        )
+
+    # -------- raw --------
+
+    def _glob_raw(self, table: str) -> str:
+        return str(self.raw_root / table / "**" / "*.parquet")
+
+    def _glob_curated(self, table: str) -> str:
+        return str(self.curated_root / table / "**" / "*.parquet")
+
+    def _safe_query(self, glob: str, where: str = "") -> pl.DataFrame:
+        from glob import glob as _glob
+
+        if not _glob(glob, recursive=True):
+            return pl.DataFrame()
+        sql = f"SELECT * FROM read_parquet('{glob}', union_by_name=true)"
+        if where:
+            sql += f" WHERE {where}"
+        arrow_tbl = self.con.execute(sql).arrow()
+        df = pl.from_arrow(arrow_tbl)
+        if isinstance(df, pl.Series):
+            df = df.to_frame()
+        return df
+
+    def list_symbols(self) -> list[str]:
+        df = self._safe_query(self._glob_raw("l2book"))
+        if df.is_empty() or "symbol" not in df.columns:
+            return []
+        return sorted(df["symbol"].unique().drop_nulls().to_list())
+
+    def load_l2book(self, symbol: str | None = None) -> pl.DataFrame:
+        where = f"symbol = '{symbol}'" if symbol else ""
+        return self._safe_query(self._glob_raw("l2book"), where)
+
+    def load_trades(self, symbol: str | None = None) -> pl.DataFrame:
+        where = f"symbol = '{symbol}'" if symbol else ""
+        return self._safe_query(self._glob_raw("trades"), where)
+
+    def load_asset_ctxs(self, symbol: str | None = None) -> pl.DataFrame:
+        where = f"symbol = '{symbol}'" if symbol else ""
+        return self._safe_query(self._glob_raw("asset_ctxs"), where)
+
+    # -------- curated --------
+
+    def load_features(self, symbol: str | None = None) -> pl.DataFrame:
+        where = f"symbol = '{symbol}'" if symbol else ""
+        return self._safe_query(self._glob_curated("features"), where)
+
+    # -------- backtest results --------
+
+    def list_backtest_strategies(self) -> list[str]:
+        bt_root = self.curated_root / "backtest_results"
+        if not bt_root.exists():
+            return []
+        return sorted(p.name for p in bt_root.iterdir() if p.is_dir())
+
+    def load_backtest_trades(
+        self,
+        strategy: str,
+        symbol: str | None = None,
+        run_id: str | None = None,
+    ) -> pl.DataFrame:
+        glob = self._glob_curated(f"backtest_results/{strategy}")
+        wheres: list[str] = []
+        if symbol:
+            wheres.append(f"symbol = '{symbol}'")
+        if run_id:
+            wheres.append(f"run_id = '{run_id}'")
+        where = " AND ".join(wheres)
+        return self._safe_query(glob, where)
+
+    # -------- KPI --------
+
+    def load_kpi_json(self, name: str) -> dict:
+        import json
+
+        p = self.kpi_dir / f"{name}.json"
+        if not p.exists():
+            return {}
+        return json.loads(p.read_text(encoding="utf-8"))
+
+    def load_kpi_md(self, name: str) -> str:
+        p = self.kpi_dir / f"{name}.md"
+        return p.read_text(encoding="utf-8") if p.exists() else ""

--- a/src/gui/perf_metrics.py
+++ b/src/gui/perf_metrics.py
@@ -1,0 +1,254 @@
+"""パフォーマンス指標: Sharpe / Sortino / Max DD / Hit Rate / Profit Factor.
+
+GUI ダッシュボードの上段で使う. 純粋数値計算なので marimo / altair に依存しない.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+
+import polars as pl
+
+
+@dataclass
+class PerfStats:
+    """戦略 backtest の performance 統計サマリ."""
+
+    n_trades: int
+    total_pnl_usd: float
+    total_cost_usd: float
+    sharpe_annualized: float
+    sharpe_se: float  # standard error
+    sharpe_ci_low: float
+    sharpe_ci_high: float
+    sortino_annualized: float
+    calmar: float
+    max_drawdown_pct: float
+    hit_rate: float
+    profit_factor: float
+    expectancy_bps: float
+    mean_bps: float
+    std_bps: float
+
+    @classmethod
+    def empty(cls) -> PerfStats:
+        return cls(
+            n_trades=0,
+            total_pnl_usd=0.0,
+            total_cost_usd=0.0,
+            sharpe_annualized=0.0,
+            sharpe_se=0.0,
+            sharpe_ci_low=0.0,
+            sharpe_ci_high=0.0,
+            sortino_annualized=0.0,
+            calmar=0.0,
+            max_drawdown_pct=0.0,
+            hit_rate=0.0,
+            profit_factor=0.0,
+            expectancy_bps=0.0,
+            mean_bps=0.0,
+            std_bps=0.0,
+        )
+
+
+def _annualization_factor(trades_df: pl.DataFrame, fallback_n_per_year: int) -> float:
+    """trades の時間軸から年間試行回数を推定し sqrt(N) を返す.
+
+    取引が時間軸で不均一なため, 「実観測期間中の取引数」から年率換算する.
+    """
+    if trades_df.height < 2:
+        return math.sqrt(max(fallback_n_per_year, 1))
+    span = trades_df["entry_ts"].max() - trades_df["entry_ts"].min()
+    if not isinstance(span, timedelta) or span.total_seconds() <= 0:
+        return math.sqrt(max(fallback_n_per_year, 1))
+    seconds_per_year = 365.25 * 24 * 3600
+    n_per_year = trades_df.height * (seconds_per_year / span.total_seconds())
+    return math.sqrt(max(n_per_year, 1.0))
+
+
+def compute_perf_stats(
+    trades: pl.DataFrame,
+    fallback_n_per_year: int = 252,
+) -> PerfStats:
+    """trades DataFrame (persistence 形式) から PerfStats を計算.
+
+    入力: persistence.trades_to_rows() が出すカラム
+        net_pnl_usd / cost_usd / net_bps / size_usd / entry_ts ...
+    """
+    if trades is None or trades.is_empty():
+        return PerfStats.empty()
+
+    df = trades.sort("entry_ts")
+    n = df.height
+    total_pnl = float(df["net_pnl_usd"].sum() or 0.0)
+    total_cost = float(df["cost_usd"].sum() or 0.0)
+
+    bps = df["net_bps"].drop_nulls()
+    if bps.is_empty():
+        return PerfStats.empty()
+    mean_bps = float(bps.mean() or 0.0)
+    std_bps = float(bps.std() or 0.0)
+
+    ann = _annualization_factor(df, fallback_n_per_year)
+    sharpe = (mean_bps / std_bps) * ann if std_bps > 0 else 0.0
+    # Sharpe SE 大標本近似: sqrt((1 + sharpe^2/2) / n)
+    se = math.sqrt((1 + (sharpe**2) / 2.0) / max(n, 1))
+    ci_low = sharpe - 1.96 * se
+    ci_high = sharpe + 1.96 * se
+
+    downside = bps.filter(bps < 0)
+    if not downside.is_empty():
+        d_std = float(downside.std() or 0.0)
+        sortino = (mean_bps / d_std) * ann if d_std > 0 else 0.0
+    else:
+        sortino = float("inf") if mean_bps > 0 else 0.0
+
+    # equity curve から max drawdown
+    cum = df.with_columns(pl.col("net_pnl_usd").cum_sum().alias("cum"))
+    cum_vals = cum["cum"].to_list()
+    peak = -math.inf
+    max_dd_usd = 0.0
+    peak_for_dd = 0.0
+    for v in cum_vals:
+        if v > peak:
+            peak = v
+        dd = v - peak  # 負値
+        if dd < max_dd_usd:
+            max_dd_usd = dd
+            peak_for_dd = peak
+    # max DD を peak からの割合へ. 初期 0 から見て最初に peak が立つまで peak=0 → 割合計算回避
+    if peak_for_dd > 0:
+        max_dd_pct = max_dd_usd / peak_for_dd
+    else:
+        # サイズに対する比率で代用 (mean size を分母に)
+        mean_size = float(df["size_usd"].abs().mean() or 1.0)
+        max_dd_pct = max_dd_usd / mean_size if mean_size > 0 else 0.0
+
+    calmar = (mean_bps / 10000.0 * ann**2) / abs(max_dd_pct) if max_dd_pct < 0 else 0.0
+
+    wins = df.filter(pl.col("net_pnl_usd") > 0).height
+    hit = wins / n if n > 0 else 0.0
+
+    sum_wins = float(df.filter(pl.col("net_pnl_usd") > 0)["net_pnl_usd"].sum() or 0.0)
+    sum_losses = float(df.filter(pl.col("net_pnl_usd") < 0)["net_pnl_usd"].sum() or 0.0)
+    pf = sum_wins / abs(sum_losses) if sum_losses < 0 else float("inf") if sum_wins > 0 else 0.0
+
+    return PerfStats(
+        n_trades=n,
+        total_pnl_usd=total_pnl,
+        total_cost_usd=total_cost,
+        sharpe_annualized=sharpe,
+        sharpe_se=se,
+        sharpe_ci_low=ci_low,
+        sharpe_ci_high=ci_high,
+        sortino_annualized=sortino,
+        calmar=calmar,
+        max_drawdown_pct=max_dd_pct,
+        hit_rate=hit,
+        profit_factor=pf,
+        expectancy_bps=mean_bps,
+        mean_bps=mean_bps,
+        std_bps=std_bps,
+    )
+
+
+def equity_curve(trades: pl.DataFrame) -> pl.DataFrame:
+    """累積 P/L 時系列. columns: ts, cum_pnl_usd, cum_pnl_bps_per_size."""
+    if trades is None or trades.is_empty():
+        return pl.DataFrame(
+            schema={
+                "ts": pl.Datetime,
+                "cum_pnl_usd": pl.Float64,
+                "cum_pnl_bps": pl.Float64,
+            }
+        )
+    df = trades.sort("entry_ts")
+    return df.with_columns(
+        [
+            pl.col("net_pnl_usd").cum_sum().alias("cum_pnl_usd"),
+            pl.col("net_bps").cum_sum().alias("cum_pnl_bps"),
+        ]
+    ).select(
+        [
+            pl.col("entry_ts").alias("ts"),
+            "cum_pnl_usd",
+            "cum_pnl_bps",
+        ]
+    )
+
+
+def underwater_curve(trades: pl.DataFrame) -> pl.DataFrame:
+    """drawdown 時系列. columns: ts, drawdown_usd, drawdown_pct.
+
+    drawdown_pct は実現 peak (>0) 比. peak が 0 以下の場合は size に対する比率.
+    """
+    if trades is None or trades.is_empty():
+        return pl.DataFrame(
+            schema={
+                "ts": pl.Datetime,
+                "drawdown_usd": pl.Float64,
+                "drawdown_pct": pl.Float64,
+            }
+        )
+    df = trades.sort("entry_ts").with_columns(pl.col("net_pnl_usd").cum_sum().alias("cum"))
+    cum_vals = df["cum"].to_list()
+    ts_vals = df["entry_ts"].to_list()
+    sizes = df["size_usd"].to_list()
+    out_ts: list[datetime] = []
+    out_dd_usd: list[float] = []
+    out_dd_pct: list[float] = []
+    peak = 0.0
+    for v, ts, sz in zip(cum_vals, ts_vals, sizes, strict=True):
+        if v > peak:
+            peak = v
+        dd_usd = v - peak  # 負値
+        if peak > 0:
+            dd_pct = dd_usd / peak
+        else:
+            base = abs(sz) if sz else 1.0
+            dd_pct = dd_usd / base
+        out_ts.append(ts)
+        out_dd_usd.append(dd_usd)
+        out_dd_pct.append(dd_pct)
+    return pl.DataFrame(
+        {
+            "ts": out_ts,
+            "drawdown_usd": out_dd_usd,
+            "drawdown_pct": out_dd_pct,
+        }
+    )
+
+
+def regime_breakdown(trades: pl.DataFrame) -> pl.DataFrame:
+    """regime (= trades に regime カラムがある場合のみ) 別 PerfStats サマリ.
+
+    Phase 1.5 では trades persistence に regime カラムが無いので, この関数は
+    将来 (FilledTrade.metadata['regime'] を埋めて persist 拡張する PR) で使う.
+    現状は呼ばれた時に空 DF を返す.
+    """
+    if trades is None or trades.is_empty() or "regime" not in trades.columns:
+        return pl.DataFrame(
+            schema={
+                "regime": pl.Utf8,
+                "n": pl.Int64,
+                "sharpe": pl.Float64,
+                "hit_rate": pl.Float64,
+                "expectancy_bps": pl.Float64,
+            }
+        )
+    rows: list[dict] = []
+    for regime in trades["regime"].unique().drop_nulls().to_list():
+        sub = trades.filter(pl.col("regime") == regime)
+        ps = compute_perf_stats(sub)
+        rows.append(
+            {
+                "regime": regime,
+                "n": ps.n_trades,
+                "sharpe": ps.sharpe_annualized,
+                "hit_rate": ps.hit_rate,
+                "expectancy_bps": ps.expectancy_bps,
+            }
+        )
+    return pl.DataFrame(rows)

--- a/src/l3_strategy/persistence.py
+++ b/src/l3_strategy/persistence.py
@@ -1,0 +1,89 @@
+"""BacktestResult の Parquet 永続化.
+
+GUI 側 (notebooks/dashboard.py) が読むための共通 schema を定義する.
+パス: data/curated/backtest_results/{strategy}/{run_id}.parquet
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+
+from src.config import StorageConfig
+from src.l1_collector.storage import write_parquet_atomic
+from src.l3_strategy.backtest import BacktestResult
+from src.logging_setup import get_logger
+
+log = get_logger("l3.persist")
+
+
+def trades_to_rows(result: BacktestResult, run_meta: dict) -> list[dict]:
+    """BacktestResult.trades を Parquet 用の row dict 列に変換."""
+    rows: list[dict] = []
+    for t in result.trades:
+        size = max(abs(t.size_usd), 1e-9)
+        net_bps = t.net_pnl_usd / size * 10000.0
+        gross_bps = t.gross_pnl_usd / size * 10000.0
+        rows.append(
+            {
+                "run_id": run_meta["run_id"],
+                "strategy_name": result.strategy_name,
+                "symbol": t.symbol,
+                "side": t.side,
+                "entry_ts": t.entry_ts,
+                "exit_ts": t.exit_ts,
+                "size_usd": t.size_usd,
+                "entry_px": t.entry_px,
+                "exit_px": t.exit_px,
+                "gross_pnl_usd": t.gross_pnl_usd,
+                "cost_usd": t.cost_usd,
+                "net_pnl_usd": t.net_pnl_usd,
+                "gross_bps": gross_bps,
+                "net_bps": net_bps,
+                "holding_minutes": t.holding_minutes,
+                # run metadata (各 trade row にも埋めて join 不要に)
+                "run_started_at": run_meta["run_started_at"],
+                "run_symbol_filter": run_meta.get("symbol_filter"),
+                "run_exit_after_minutes": run_meta.get("exit_after_minutes"),
+                "run_taker_fee_rate": run_meta.get("taker_fee_rate"),
+                "run_funding_multiplier": run_meta.get("funding_multiplier"),
+            }
+        )
+    return rows
+
+
+def save_backtest_result(
+    result: BacktestResult,
+    cfg: StorageConfig,
+    *,
+    symbol_filter: str | None,
+    exit_after_minutes: int,
+    taker_fee_rate: float,
+    funding_multiplier: float,
+) -> Path | None:
+    """BacktestResult を data/curated/backtest_results/{strategy}/ 以下に Parquet 保存."""
+    run_id = uuid.uuid4().hex[:12]
+    run_meta = {
+        "run_id": run_id,
+        "run_started_at": datetime.now(UTC),
+        "symbol_filter": symbol_filter,
+        "exit_after_minutes": exit_after_minutes,
+        "taker_fee_rate": taker_fee_rate,
+        "funding_multiplier": funding_multiplier,
+    }
+    rows = trades_to_rows(result, run_meta)
+    if not rows:
+        log.warning("backtest.persist.empty", strategy=result.strategy_name, run_id=run_id)
+        return None
+
+    table = f"backtest_results/{result.strategy_name}"
+    out = write_parquet_atomic(rows, table, cfg, use_curated=True)
+    log.info(
+        "backtest.persist.saved",
+        strategy=result.strategy_name,
+        run_id=run_id,
+        n_trades=len(rows),
+        path=str(out) if out else None,
+    )
+    return out

--- a/tests/test_charts.py
+++ b/tests/test_charts.py
@@ -1,0 +1,39 @@
+"""altair チャート関数の smoke test (戻り値が Chart, 空 input でもエラー無し)."""
+
+from __future__ import annotations
+
+import altair as alt
+import polars as pl
+
+from src.gui.charts import (
+    book_top_depth_chart,
+    equity_curve_chart,
+    ipd_time_series_chart,
+    trade_pnl_histogram,
+    underwater_chart,
+)
+
+
+def test_equity_curve_handles_empty() -> None:
+    c = equity_curve_chart(pl.DataFrame())
+    assert isinstance(c, alt.Chart)
+
+
+def test_underwater_handles_empty() -> None:
+    c = underwater_chart(pl.DataFrame())
+    assert isinstance(c, alt.Chart)
+
+
+def test_trade_pnl_histogram_empty() -> None:
+    c = trade_pnl_histogram(pl.DataFrame())
+    assert isinstance(c, alt.Chart)
+
+
+def test_ipd_time_series_handles_empty() -> None:
+    c = ipd_time_series_chart(pl.DataFrame(), "BTC")
+    assert isinstance(c, alt.Chart)
+
+
+def test_book_top_depth_handles_empty() -> None:
+    c = book_top_depth_chart(pl.DataFrame(), "BTC")
+    assert isinstance(c, alt.Chart)

--- a/tests/test_data_access.py
+++ b/tests/test_data_access.py
@@ -1,0 +1,38 @@
+"""GuiDataSource の安全な動作テスト (空ディレクトリで落ちない)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from src.config import StorageConfig
+from src.gui.data_access import GuiDataSource
+
+
+def test_empty_dirs_do_not_crash(tmp_path: Path) -> None:
+    storage = StorageConfig(
+        raw_data_root=tmp_path / "raw",
+        curated_data_root=tmp_path / "curated",
+    )
+    ds = GuiDataSource.from_config(storage, kpi_dir=tmp_path / "kpi")
+
+    assert ds.list_symbols() == []
+    assert ds.load_l2book().is_empty()
+    assert ds.load_trades().is_empty()
+    assert ds.load_asset_ctxs().is_empty()
+    assert ds.load_features().is_empty()
+    assert ds.list_backtest_strategies() == []
+    assert ds.load_backtest_trades("nonexistent").is_empty()
+    assert ds.load_kpi_json("nonexistent") == {}
+    assert ds.load_kpi_md("nonexistent") == ""
+
+
+def test_load_kpi_md_when_present(tmp_path: Path) -> None:
+    storage = StorageConfig(
+        raw_data_root=tmp_path / "raw",
+        curated_data_root=tmp_path / "curated",
+    )
+    kpi = tmp_path / "kpi"
+    kpi.mkdir()
+    (kpi / "K1.md").write_text("# Hello", encoding="utf-8")
+    ds = GuiDataSource.from_config(storage, kpi_dir=kpi)
+    assert ds.load_kpi_md("K1") == "# Hello"

--- a/tests/test_perf_metrics.py
+++ b/tests/test_perf_metrics.py
@@ -1,0 +1,109 @@
+"""perf_metrics の数値テスト."""
+
+from __future__ import annotations
+
+import math
+from datetime import UTC, datetime, timedelta
+
+import polars as pl
+
+from src.gui.perf_metrics import (
+    PerfStats,
+    compute_perf_stats,
+    equity_curve,
+    underwater_curve,
+)
+
+
+def _trade_row(*, ts: datetime, net_pnl: float, size: float = 1000.0) -> dict:
+    return {
+        "entry_ts": ts,
+        "exit_ts": ts + timedelta(minutes=30),
+        "symbol": "xyz:SP500",
+        "side": "long",
+        "size_usd": size,
+        "net_pnl_usd": net_pnl,
+        "cost_usd": 0.5,
+        "net_bps": net_pnl / size * 10000.0,
+        "gross_bps": (net_pnl + 0.5) / size * 10000.0,
+        "gross_pnl_usd": net_pnl + 0.5,
+        "entry_px": 100.0,
+        "exit_px": 100.0 + net_pnl / size * 100.0,
+        "holding_minutes": 30.0,
+    }
+
+
+def test_empty_returns_empty_stats() -> None:
+    df = pl.DataFrame()
+    ps = compute_perf_stats(df)
+    assert ps == PerfStats.empty()
+
+
+def test_all_winners_profit_factor_inf() -> None:
+    base = datetime(2026, 5, 9, 12, tzinfo=UTC)
+    rows = [_trade_row(ts=base + timedelta(hours=i), net_pnl=10.0) for i in range(10)]
+    df = pl.DataFrame(rows)
+    ps = compute_perf_stats(df)
+    assert ps.n_trades == 10
+    assert ps.hit_rate == 1.0
+    assert math.isinf(ps.profit_factor)
+    assert ps.total_pnl_usd == 100.0
+
+
+def test_mixed_pnl_metrics_match_handcalc() -> None:
+    base = datetime(2026, 5, 9, 12, tzinfo=UTC)
+    pnls = [10.0, -5.0, 20.0, -8.0, 15.0]
+    rows = [_trade_row(ts=base + timedelta(hours=i), net_pnl=p) for i, p in enumerate(pnls)]
+    df = pl.DataFrame(rows)
+    ps = compute_perf_stats(df)
+    assert ps.n_trades == 5
+    assert ps.total_pnl_usd == sum(pnls)
+    # hit rate = 3/5
+    assert abs(ps.hit_rate - 0.6) < 1e-9
+    # profit factor = (10+20+15) / (5+8) = 45/13
+    assert abs(ps.profit_factor - 45 / 13) < 1e-6
+    # mean_bps = mean(pnls) / 1000 * 10000 = mean(pnls) * 10
+    assert abs(ps.mean_bps - sum(pnls) / len(pnls) * 10) < 1e-6
+
+
+def test_max_drawdown_negative() -> None:
+    base = datetime(2026, 5, 9, 12, tzinfo=UTC)
+    pnls = [10.0, 5.0, -30.0, 5.0]  # peak=15, trough=-15 → DD=-30
+    rows = [_trade_row(ts=base + timedelta(hours=i), net_pnl=p) for i, p in enumerate(pnls)]
+    df = pl.DataFrame(rows)
+    ps = compute_perf_stats(df)
+    # max_dd_pct: peak(15) からの drawdown = -30 → -30/15 = -2.0
+    assert ps.max_drawdown_pct < 0
+    assert ps.max_drawdown_pct == -2.0
+
+
+def test_sharpe_positive_when_mean_positive() -> None:
+    base = datetime(2026, 5, 9, 12, tzinfo=UTC)
+    pnls = [10.0, 8.0, 12.0, 11.0, 9.0, 10.5, 11.5, 10.0]
+    rows = [_trade_row(ts=base + timedelta(hours=i), net_pnl=p) for i, p in enumerate(pnls)]
+    df = pl.DataFrame(rows)
+    ps = compute_perf_stats(df)
+    assert ps.sharpe_annualized > 0
+    assert ps.sharpe_ci_low < ps.sharpe_annualized < ps.sharpe_ci_high
+
+
+def test_equity_and_underwater_curves_have_n_rows() -> None:
+    base = datetime(2026, 5, 9, 12, tzinfo=UTC)
+    rows = [
+        _trade_row(ts=base + timedelta(hours=i), net_pnl=p) for i, p in enumerate([5.0, -3.0, 10.0])
+    ]
+    df = pl.DataFrame(rows)
+
+    eq = equity_curve(df)
+    assert eq.height == 3
+    cum = eq["cum_pnl_usd"].to_list()
+    assert cum[0] == 5.0
+    assert cum[1] == 2.0
+    assert cum[2] == 12.0
+
+    uw = underwater_curve(df)
+    assert uw.height == 3
+    # peak は 5 → -3 で trough = 2 → DD = -3, peak 12 で 0
+    dd = uw["drawdown_usd"].to_list()
+    assert max(dd) == 0.0  # peak の瞬間
+    assert min(dd) <= -3.0

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -1,0 +1,98 @@
+"""BacktestResult の Parquet 永続化テスト (PR-A)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pyarrow.parquet as pq
+
+from src.config import StorageConfig
+from src.l3_strategy.backtest import BacktestResult
+from src.l3_strategy.interface import FilledTrade
+from src.l3_strategy.persistence import save_backtest_result
+
+
+def _trade(symbol: str = "xyz:SP500", net: float = 5.0) -> FilledTrade:
+    return FilledTrade(
+        entry_ts=datetime(2026, 5, 9, 12, 0, tzinfo=UTC),
+        exit_ts=datetime(2026, 5, 9, 12, 30, tzinfo=UTC),
+        symbol=symbol,
+        side="long",
+        size_usd=1000.0,
+        entry_px=100.0,
+        exit_px=100.5,
+        gross_pnl_usd=5.0 + net,  # placeholder
+        cost_usd=net * 0.5,
+        net_pnl_usd=net,
+        holding_minutes=30.0,
+    )
+
+
+def test_save_creates_parquet(tmp_path: Path) -> None:
+    cfg = StorageConfig(curated_data_root=tmp_path / "curated")
+    result = BacktestResult(
+        strategy_name="H1_test",
+        n_trades=2,
+        gross_pnl_usd=20.0,
+        cost_usd=2.0,
+        net_pnl_usd=18.0,
+        mean_net_bps=10.0,
+        std_net_bps=2.0,
+        se_bps=1.0,
+        win_rate=1.0,
+        trades=[_trade(net=5.0), _trade(net=3.0)],
+    )
+    out = save_backtest_result(
+        result,
+        cfg,
+        symbol_filter="xyz:SP500",
+        exit_after_minutes=60,
+        taker_fee_rate=0.00045,
+        funding_multiplier=0.5,
+    )
+    assert out is not None and out.exists()
+
+    table = pq.read_table(out)
+    assert table.num_rows == 2
+    cols = set(table.column_names)
+    expected = {
+        "run_id",
+        "strategy_name",
+        "symbol",
+        "side",
+        "entry_ts",
+        "exit_ts",
+        "net_pnl_usd",
+        "net_bps",
+        "gross_bps",
+        "run_started_at",
+        "run_taker_fee_rate",
+        "run_funding_multiplier",
+    }
+    assert expected.issubset(cols)
+
+
+def test_save_empty_returns_none(tmp_path: Path) -> None:
+    cfg = StorageConfig(curated_data_root=tmp_path / "curated")
+    result = BacktestResult(
+        strategy_name="H1_empty",
+        n_trades=0,
+        gross_pnl_usd=0.0,
+        cost_usd=0.0,
+        net_pnl_usd=0.0,
+        mean_net_bps=0.0,
+        std_net_bps=0.0,
+        se_bps=0.0,
+        win_rate=0.0,
+        trades=[],
+    )
+    out = save_backtest_result(
+        result,
+        cfg,
+        symbol_filter=None,
+        exit_after_minutes=60,
+        taker_fee_rate=0.00045,
+        funding_multiplier=0.5,
+    )
+    assert out is None


### PR DESCRIPTION
## Summary
analytics dashboard 完備. 取得済み Parquet データを marimo + altair で対話可視化.

## 主要 PR (develop merge 済)
- PR #48: analytics dashboard (PR-A backtest persist + PR-B src/gui + PR-C notebooks/dashboard.py)

## 主要追加
- src/gui/ (data_access + perf_metrics + charts)
- notebooks/dashboard.py (marimo 0.23.4 reactive notebook)
- 8 標準 KPI (Sharpe + 95% CI / Sortino / Max DD / Hit Rate / PF / Expectancy)
- KPI カード (K1-K9 + fat_tail + regime_diff)
- 自由探索セル (IPD / top-of-book / DuckDB SQL)

## 状態
- 61/61 tests pass
- ruff/format clean
- CI green
- Quick start: `pip install -e '.[dev,gui]' && marimo edit notebooks/dashboard.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)