### PR TITLE
fix(ci): install gui+audit extras for full test collection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]"
+          pip install -e ".[dev,gui,audit]"
 
       - name: Ruff lint
         run: ruff check src tests


### PR DESCRIPTION
PR #50 で gui/audit テストが追加されたが CI が dev のみ install していた. 全 extras を install するよう修正.