### PR TITLE
fix: CI install gui+audit extras (v0.4.1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]"
+          pip install -e ".[dev,gui,audit]"
 
       - name: Ruff lint
         run: ruff check src tests


### PR DESCRIPTION
PR #53 merge を main に同期. CI が gui/audit テストの依存をインストールしないため failed していた問題を修正.