### PR TITLE
fix(ci): all extra + importorskip + push前検証スクリプト (CI 失敗再発防止)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,12 @@ jobs:
           cache: pip
 
       - name: Install dependencies
+        # "all" は機能 extras (gui/audit/...) をまとめた meta extra.
+        # extras 追加時は pyproject.toml の "all" にも必ず反映すること.
+        # Gemini partner レビュー (2026-05-04) で推奨されたデファクト構成.
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev,gui,audit]"
+          pip install -e ".[dev,all]"
 
       - name: Ruff lint
         run: ruff check src tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,20 @@ docs/{topic}           ← ドキュメントのみ
 - PR は `develop` に向けて作る (Phase完了で `develop` → `main`)
 - 命名: `feat/issue-12-l1-ws-client`、`fix/issue-25-ema-edge-case`
 
+## Push 前検証 (CI 失敗の再発防止)
+
+Gemini partner レビュー (2026-05-04) で確立した手順:
+
+```bash
+bash scripts/check_ci_local.sh   # CI と同じコマンドをローカル実行
+```
+
+これが green な状態でしか push しない. 失敗したら修正してから push.
+
+依存追加時:
+- `pyproject.toml` の該当 extra (gui / audit / ...) に追加した後,
+  必ず `all` extra にも反映する (CI が `.[dev,all]` を install するため).
+
 ## Definition of Done (DoD)
 
 各 Issue / PR は以下を満たす:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,17 @@ audit = [
     # DuckDB の datetime 計算で必要
     "pytz>=2025.1",
 ]
+# "all" は dev 以外 (= 機能 extras) をまとめたメタ extra.
+# CI / ローカル全部入り環境用. extras を増やしたら必ずここにも追加する.
+all = [
+    # gui
+    "marimo[recommended]~=0.23.4",
+    "altair~=6.1.0",
+    "pandas>=2.0",
+    # audit
+    "yfinance~=1.3.0",
+    "pytz>=2025.1",
+]
 
 [project.scripts]
 diff-old-new = "src.cli:app"

--- a/scripts/check_ci_local.sh
+++ b/scripts/check_ci_local.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# CI と同じコマンドをローカル実行して push 前に検証する.
+# Gemini partner 推奨 (2026-05-04): CI 失敗を push 前に検出して再発防止.
+#
+# 使い方: bash scripts/check_ci_local.sh
+# 推奨: git pre-push hook に登録 (.git/hooks/pre-push) or 手動実行
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+if [[ ! -d .venv ]]; then
+    echo "ERROR: .venv not found. Run: python3.12 -m venv .venv && pip install -e '.[dev,all]'" >&2
+    exit 1
+fi
+
+echo "=== CI replay ==="
+echo ""
+
+echo "[1/4] Install check (CI と同じ pip install)..."
+.venv/bin/pip install -e ".[dev,all]" --quiet 2>&1 | tail -3
+
+echo ""
+echo "[2/4] Ruff lint..."
+.venv/bin/ruff check src tests
+
+echo ""
+echo "[3/4] Ruff format check..."
+.venv/bin/ruff format --check src tests
+
+echo ""
+echo "[4/4] Pytest (CI と同じ marker filter)..."
+.venv/bin/pytest -q -m "not live and not slow" --cov=src --cov-report=term-missing | tail -5
+
+echo ""
+echo "=== ✓ All CI checks passed locally ==="

--- a/tests/test_charts.py
+++ b/tests/test_charts.py
@@ -1,11 +1,18 @@
-"""altair チャート関数の smoke test (戻り値が Chart, 空 input でもエラー無し)."""
+"""altair チャート関数の smoke test (戻り値が Chart, 空 input でもエラー無し).
+
+dev extra のみで pytest を回したい場合 (gui extra 未インストール) に skip するため
+モジュール全体を pytest.importorskip でガード.
+"""
 
 from __future__ import annotations
 
-import altair as alt
-import polars as pl
+import pytest
 
-from src.gui.charts import (
+alt = pytest.importorskip("altair", reason="altair not installed (gui extra)")
+
+import polars as pl  # noqa: E402
+
+from src.gui.charts import (  # noqa: E402
     book_top_depth_chart,
     equity_curve_chart,
     ipd_time_series_chart,


### PR DESCRIPTION
## Summary
本セッションで CI 失敗を 5 回繰り返した根本原因 (extras 分離設計の運用漏れ) に対し,
Gemini partner と相談して立てた再発防止策.

## Gemini 推奨 (A + B 採用)
- **A: all extra**: 機能 extras (gui/audit) を 1 つにまとめ CI install を `.[dev,all]` に統一
- **B: pytest.importorskip**: gui テストでモジュール全体を skip 可能に (dev のみ環境用フォールバック)
- C (matrix) / D (auto-parse) / E (pre-commit) は Phase 1.5 ではオーバーエンジ

## 変更
- `pyproject.toml`: 新規 `all` extra
- `.github/workflows/ci.yml`: `.[dev,all]` install + 運用ルールコメント
- `tests/test_charts.py`: `pytest.importorskip('altair')`
- `scripts/check_ci_local.sh` 新規: CI と同じコマンドを push 前にローカル実行
- `CONTRIBUTING.md`: "Push 前検証" セクション + "all への反映" ルール

## ローカル検証 (CI と同じコマンド)
```
$ bash scripts/check_ci_local.sh
=== ✓ All CI checks passed locally ===
71/71 tests pass, ruff/format clean
```

## DoD
- [x] check_ci_local.sh で完走
- [x] Gemini partner レビュー通過
- [x] CONTRIBUTING.md に運用ルール反映

🤖 Generated with [Claude Code](https://claude.com/claude-code)