### PR TITLE
feat(executor-server): PR-7 axum REST + WS server

### DIFF
--- a/executor/Cargo.lock
+++ b/executor/Cargo.lock
@@ -486,15 +486,25 @@ name = "executor-server"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "axum",
+ "chrono",
  "executor-algo",
  "executor-core",
  "executor-hl",
+ "futures",
+ "rstest",
+ "rust_decimal",
+ "rust_decimal_macros",
  "serde",
  "serde_json",
+ "thiserror 2.0.18",
  "tokio",
+ "tower",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]
@@ -2302,6 +2312,7 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]

--- a/executor/crates/executor-server/Cargo.toml
+++ b/executor/crates/executor-server/Cargo.toml
@@ -15,14 +15,30 @@ workspace = true
 name = "executor-server"
 path = "src/main.rs"
 
+[lib]
+path = "src/lib.rs"
+
 [dependencies]
 executor-core = { workspace = true }
 executor-hl = { workspace = true }
 executor-algo = { workspace = true }
 tokio = { workspace = true }
 axum = { workspace = true }
+tower = { workspace = true }
+tower-http = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 anyhow = { workspace = true }
+thiserror = { workspace = true }
+chrono = { workspace = true }
+rust_decimal = { workspace = true }
+futures = { workspace = true }
+async-trait = { workspace = true }
+uuid = { workspace = true }
+
+[dev-dependencies]
+rstest = { workspace = true }
+rust_decimal_macros = { workspace = true }
+tokio = { workspace = true, features = ["full", "test-util", "macros"] }

--- a/executor/crates/executor-server/src/error.rs
+++ b/executor/crates/executor-server/src/error.rs
@@ -1,0 +1,71 @@
+//! HTTP-mappable error type. We never leak `anyhow!` chains to clients.
+
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use serde::Serialize;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum ServerError {
+    #[error("execution {0} not found")]
+    NotFound(String),
+
+    #[error("invalid request: {0}")]
+    BadRequest(String),
+
+    #[error("conflict: {0}")]
+    Conflict(String),
+
+    #[error("internal error: {0}")]
+    Internal(String),
+}
+
+#[derive(Serialize)]
+struct ErrorBody<'a> {
+    code: &'a str,
+    message: String,
+}
+
+impl IntoResponse for ServerError {
+    fn into_response(self) -> Response {
+        let (status, code, msg) = match &self {
+            ServerError::NotFound(_) => (StatusCode::NOT_FOUND, "not_found", self.to_string()),
+            ServerError::BadRequest(_) => {
+                (StatusCode::BAD_REQUEST, "bad_request", self.to_string())
+            }
+            ServerError::Conflict(_) => (StatusCode::CONFLICT, "conflict", self.to_string()),
+            // Gemini PR-7 review: never leak `Internal` details to clients —
+            // anyhow chains may carry stack traces, file paths, or secrets.
+            // Log server-side, return a generic message to the caller.
+            ServerError::Internal(detail) => {
+                tracing::error!(detail, "internal server error");
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "internal",
+                    "internal server error".to_string(),
+                )
+            }
+        };
+        (status, Json(ErrorBody { code, message: msg })).into_response()
+    }
+}
+
+impl From<executor_core::errors::AlgoError> for ServerError {
+    fn from(e: executor_core::errors::AlgoError) -> Self {
+        ServerError::BadRequest(format!("algo: {e}"))
+    }
+}
+
+impl From<executor_core::errors::ExecutorError> for ServerError {
+    fn from(e: executor_core::errors::ExecutorError) -> Self {
+        use executor_core::errors::ExecutorError;
+        match e {
+            ExecutorError::ExecutionNotFound(s) => ServerError::NotFound(s),
+            ExecutorError::ExecutionAlreadyRunning(s) => ServerError::Conflict(s),
+            ExecutorError::InvalidRequest(s) => ServerError::BadRequest(s),
+            ExecutorError::Algo(a) => ServerError::BadRequest(format!("algo: {a}")),
+            ExecutorError::Internal(s) => ServerError::Internal(s),
+        }
+    }
+}

--- a/executor/crates/executor-server/src/lib.rs
+++ b/executor/crates/executor-server/src/lib.rs
@@ -1,0 +1,50 @@
+//! executor-server: axum REST + WS server.
+//!
+//! Wires the algorithms (executor-algo) to a transport so external systems
+//! (the Python research stack, ops dashboards, the CLI) can drive executions.
+//!
+//! Responsibilities:
+//! - Hold the shared `AppState` (book / position / open_orders / fills / health)
+//!   and the `BatchSender` flusher started at `serve()` time.
+//! - Accept REST requests to start/cancel/inspect executions.
+//! - Stream `Progress` events over WS for any execution id.
+//! - Snapshot health, positions, and books for sanity checks.
+//!
+//! 80 % prototype: uses `MockHlClient` + `MockSigner` from executor-hl. Real
+//! networking + signing is wired up in a later PR after key-management
+//! brainstorming.
+
+#![forbid(unsafe_code)]
+
+pub mod error;
+pub mod registry;
+pub mod router;
+pub mod routes;
+pub mod state;
+pub mod ws;
+
+pub use error::ServerError;
+pub use registry::{ExecutionHandle, ExecutionRegistry, ExecutionStatus};
+pub use router::OrderRouter;
+pub use state::ServerState;
+
+use std::sync::Arc;
+
+use axum::routing::{get, post};
+use axum::Router;
+use tower_http::trace::TraceLayer;
+
+/// Build the axum application router. The returned `Router` is ready to
+/// be served via `axum::serve`.
+pub fn build_app(state: Arc<ServerState>) -> Router {
+    Router::new()
+        .route("/v1/health", get(routes::health))
+        .route("/v1/positions", get(routes::positions))
+        .route("/v1/book/{symbol}", get(routes::book))
+        .route("/v1/exec", post(routes::start_exec))
+        .route("/v1/exec/{id}", get(routes::get_exec))
+        .route("/v1/exec/{id}/cancel", post(routes::cancel_exec))
+        .route("/v1/exec/{id}/ws", get(ws::progress_ws))
+        .layer(TraceLayer::new_for_http())
+        .with_state(state)
+}

--- a/executor/crates/executor-server/src/main.rs
+++ b/executor/crates/executor-server/src/main.rs
@@ -1,7 +1,55 @@
-//! executor-server: axum REST + WS bin (PR-7 で実装).
+//! executor-server: axum REST + WS bin (PR-7).
+//!
+//! 80 % prototype: uses `MockHlClient` + `MockSigner` so it runs end-to-end
+//! without keys or networking. Real signer + real HL POST will be wired in a
+//! follow-up after key-management brainstorming.
 
 #![forbid(unsafe_code)]
 
-fn main() {
-    println!("executor-server placeholder (PR-7)");
+use std::sync::Arc;
+use std::time::Duration;
+
+use executor_core::state::AppState;
+use executor_hl::batch_sender::{spawn_batch_sender, BatchSenderConfig};
+use executor_hl::hl_client::MockHlClient;
+use executor_hl::signer::MockSigner;
+use executor_server::{build_app, ServerState};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info,executor_=debug")),
+        )
+        .with_target(true)
+        .compact()
+        .init();
+
+    let app_state = Arc::new(AppState::new());
+    let mock_hl: Arc<MockHlClient> = Arc::new(MockHlClient::new());
+    let signer = Arc::new(MockSigner::new());
+
+    let (batch_sender, batch_handle) = spawn_batch_sender(
+        mock_hl.clone(),
+        BatchSenderConfig {
+            flush_interval: Duration::from_millis(100),
+            max_batch_size: 50,
+        },
+    );
+
+    let state = Arc::new(ServerState::new(
+        app_state,
+        mock_hl,
+        signer,
+        batch_sender,
+        batch_handle,
+    ));
+
+    let app = build_app(state);
+    let bind = std::env::var("EXECUTOR_BIND").unwrap_or_else(|_| "0.0.0.0:8085".into());
+    tracing::info!(%bind, "executor-server listening");
+    let listener = tokio::net::TcpListener::bind(&bind).await?;
+    axum::serve(listener, app).await?;
+    Ok(())
 }

--- a/executor/crates/executor-server/src/registry.rs
+++ b/executor/crates/executor-server/src/registry.rs
@@ -1,0 +1,183 @@
+//! Registry of running and completed executions.
+//!
+//! Holds one entry per `ExecutionId`:
+//! - the `JoinHandle` of the algorithm task
+//! - an `abort` `watch::Sender` to ask the algo to stop
+//! - a `broadcast::Sender<Progress>` so multiple WS subscribers can stream
+//!   the same execution
+//! - the final `ExecutionReport` once the task finishes
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use executor_core::errors::AlgoError;
+use executor_core::intent::{ExecutionId, ExecutionReport, Progress};
+use tokio::sync::{broadcast, watch, RwLock};
+use tokio::task::JoinHandle;
+
+/// Per-execution status as observed by the server.
+///
+/// `Finalizing` covers the (very brief) window between the algo task ending
+/// and the server having awaited the join handle to extract the final
+/// `ExecutionReport`. It exists to give concurrent GETs an unambiguous
+/// "almost done, come back in a moment" signal — Gemini PR-7 review.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExecutionStatus {
+    Running,
+    Finalizing,
+    Completed,
+    Aborted,
+    Failed,
+}
+
+#[derive(Debug)]
+pub struct ExecutionHandle {
+    pub exec_id: ExecutionId,
+    pub algorithm: String,
+    pub abort: watch::Sender<bool>,
+    pub progress: broadcast::Sender<Progress>,
+    pub join: Option<JoinHandle<Result<ExecutionReport, AlgoError>>>,
+    pub status: ExecutionStatus,
+    pub final_report: Option<ExecutionReport>,
+    pub final_error: Option<String>,
+}
+
+impl ExecutionHandle {
+    pub fn new(
+        exec_id: ExecutionId,
+        algorithm: String,
+        abort: watch::Sender<bool>,
+        progress: broadcast::Sender<Progress>,
+        join: JoinHandle<Result<ExecutionReport, AlgoError>>,
+    ) -> Self {
+        Self {
+            exec_id,
+            algorithm,
+            abort,
+            progress,
+            join: Some(join),
+            status: ExecutionStatus::Running,
+            final_report: None,
+            final_error: None,
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct ExecutionRegistry {
+    inner: RwLock<HashMap<ExecutionId, Arc<RwLock<ExecutionHandle>>>>,
+}
+
+impl ExecutionRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub async fn insert(&self, handle: ExecutionHandle) {
+        let exec_id = handle.exec_id;
+        let mut g = self.inner.write().await;
+        g.insert(exec_id, Arc::new(RwLock::new(handle)));
+    }
+
+    pub async fn get(&self, exec_id: &ExecutionId) -> Option<Arc<RwLock<ExecutionHandle>>> {
+        let g = self.inner.read().await;
+        g.get(exec_id).cloned()
+    }
+
+    pub async fn list(&self) -> Vec<ExecutionId> {
+        let g = self.inner.read().await;
+        g.keys().copied().collect()
+    }
+
+    /// Signal abort to every running execution. Returns the count signaled.
+    /// Used by `POST /v1/emergency_stop` (PR-8). Holds the registry read lock
+    /// only briefly to collect the abort senders.
+    pub async fn abort_all(&self) -> usize {
+        let entries: Vec<_> = {
+            let g = self.inner.read().await;
+            g.values().cloned().collect()
+        };
+        let mut signaled = 0usize;
+        for entry in entries {
+            let h = entry.read().await;
+            if h.status == ExecutionStatus::Running && h.abort.send(true).is_ok() {
+                signaled += 1;
+            }
+        }
+        signaled
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::*;
+
+    #[tokio::test]
+    async fn register_and_lookup() {
+        let reg = ExecutionRegistry::new();
+        let id = ExecutionId::new();
+        let (abort_tx, _abort_rx) = watch::channel(false);
+        let (prog_tx, _) = broadcast::channel(16);
+        let join = tokio::spawn(async {
+            Err::<ExecutionReport, AlgoError>(AlgoError::Aborted("test".into()))
+        });
+        reg.insert(ExecutionHandle::new(
+            id,
+            "test".into(),
+            abort_tx,
+            prog_tx,
+            join,
+        ))
+        .await;
+        assert!(reg.get(&id).await.is_some());
+        assert_eq!(reg.list().await.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn missing_id_returns_none() {
+        let reg = ExecutionRegistry::new();
+        let id = ExecutionId::new();
+        assert!(reg.get(&id).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn abort_all_signals_each_running_execution() {
+        let reg = ExecutionRegistry::new();
+        // Spin up two synthetic handles in Running state.
+        for _ in 0..2 {
+            let id = ExecutionId::new();
+            let (abort_tx, mut abort_rx) = watch::channel(false);
+            let (prog_tx, _) = broadcast::channel(8);
+            let join = tokio::spawn(async move {
+                while !*abort_rx.borrow() {
+                    let _ = abort_rx.changed().await;
+                }
+                Ok::<_, AlgoError>(ExecutionReport {
+                    exec_id: id,
+                    algorithm: "test".into(),
+                    started_at: chrono::Utc::now(),
+                    finished_at: chrono::Utc::now(),
+                    target_size: rust_decimal::Decimal::ZERO,
+                    filled_size: rust_decimal::Decimal::ZERO,
+                    avg_px: None,
+                    total_fees: rust_decimal::Decimal::ZERO,
+                    fills: vec![],
+                    aborted: true,
+                    abort_reason: Some("test".into()),
+                })
+            });
+            reg.insert(ExecutionHandle::new(
+                id,
+                "test".into(),
+                abort_tx,
+                prog_tx,
+                join,
+            ))
+            .await;
+        }
+        let signaled = reg.abort_all().await;
+        assert_eq!(signaled, 2);
+    }
+}

--- a/executor/crates/executor-server/src/router.rs
+++ b/executor/crates/executor-server/src/router.rs
@@ -1,0 +1,99 @@
+//! `OrderRouter` — name → Algorithm dispatcher.
+//!
+//! Selects the right `Algorithm` impl from a string name, so the REST/CLI
+//! surface can refer to algorithms by their wire name ("market", "twap", ...).
+
+use std::collections::HashSet;
+
+use executor_algo::{
+    Algorithm, MarketAlgorithm, MarketMakeAlgorithm, PassiveFollowAlgorithm, TwapAlgorithm,
+};
+use executor_core::errors::ExecutorError;
+
+/// Build a fresh boxed Algorithm from its wire name. Used by the server when
+/// kicking off a new execution.
+pub struct OrderRouter;
+
+impl OrderRouter {
+    pub fn build(name: &str) -> Result<Box<dyn Algorithm>, ExecutorError> {
+        let normalized = name.trim().to_ascii_lowercase();
+        match normalized.as_str() {
+            "market" => Ok(Box::new(MarketAlgorithm::new())),
+            "passive" | "passive_follow" => Ok(Box::new(PassiveFollowAlgorithm::new())),
+            "twap" => Ok(Box::new(TwapAlgorithm::new())),
+            "market_make" | "mm" => Ok(Box::new(MarketMakeAlgorithm::new())),
+            other => Err(ExecutorError::InvalidRequest(format!(
+                "unknown algorithm: '{other}'. supported: market / passive / twap / market_make"
+            ))),
+        }
+    }
+
+    /// Reportable list of supported algorithms (for /v1/health / docs).
+    pub fn supported() -> Vec<&'static str> {
+        vec!["market", "passive", "twap", "market_make"]
+    }
+}
+
+/// Validate that the requested algorithm name is supported. Returns an error
+/// when not (rather than panicking when the server tries to spawn it).
+pub fn validate_algorithm_name(name: &str) -> Result<(), ExecutorError> {
+    let supported: HashSet<&'static str> = OrderRouter::supported().into_iter().collect();
+    let normalized = name.trim().to_ascii_lowercase();
+    let canonical = match normalized.as_str() {
+        "passive_follow" => "passive",
+        "mm" => "market_make",
+        other => other,
+    };
+    if supported.contains(canonical) {
+        Ok(())
+    } else {
+        Err(ExecutorError::InvalidRequest(format!(
+            "unknown algorithm: '{name}'"
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::*;
+
+    #[test]
+    fn build_each_supported() {
+        for n in [
+            "market",
+            "passive",
+            "passive_follow",
+            "twap",
+            "market_make",
+            "mm",
+        ] {
+            let algo = OrderRouter::build(n).unwrap();
+            assert!(!algo.name().is_empty());
+        }
+    }
+
+    #[test]
+    fn build_unknown_errors() {
+        assert!(OrderRouter::build("vwap").is_err());
+        assert!(OrderRouter::build("").is_err());
+    }
+
+    #[test]
+    fn build_is_case_insensitive() {
+        assert!(OrderRouter::build("MARKET").is_ok());
+        assert!(OrderRouter::build("Twap").is_ok());
+        assert!(OrderRouter::build("Market_Make").is_ok());
+    }
+
+    #[test]
+    fn validate_accepts_synonyms() {
+        assert!(validate_algorithm_name("passive_follow").is_ok());
+        assert!(validate_algorithm_name("mm").is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_typos() {
+        assert!(validate_algorithm_name("twapp").is_err());
+    }
+}

--- a/executor/crates/executor-server/src/routes.rs
+++ b/executor/crates/executor-server/src/routes.rs
@@ -1,0 +1,231 @@
+//! REST handlers.
+//!
+//! - `GET /v1/health` — health snapshot
+//! - `GET /v1/positions` — current positions
+//! - `GET /v1/book/{symbol}` — top-of-book snapshot for one symbol
+//! - `POST /v1/exec` — start an execution
+//! - `GET /v1/exec/{id}` — execution status / final report
+//! - `POST /v1/exec/{id}/cancel` — request abort
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use axum::extract::{Path, State};
+use axum::Json;
+use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
+use tokio::sync::{broadcast, watch};
+
+use executor_algo::ExecutionContext;
+use executor_core::intent::{AlgoParams, ExecutionId, ExecutionReport, Intent, Progress};
+use executor_core::state::{HealthStatus, OrderBook, Position};
+use executor_core::symbol::Symbol;
+
+use crate::error::ServerError;
+use crate::registry::{ExecutionHandle, ExecutionStatus};
+use crate::router::{validate_algorithm_name, OrderRouter};
+use crate::state::ServerState;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct HealthResponse {
+    pub status: &'static str,
+    pub algorithms: Vec<&'static str>,
+    pub health: HealthStatus,
+    pub running_executions: usize,
+}
+
+pub async fn health(
+    State(s): State<Arc<ServerState>>,
+) -> Result<Json<HealthResponse>, ServerError> {
+    let h = s.app_state.health.read().await.clone();
+    let running = s.registry.list().await.len();
+    Ok(Json(HealthResponse {
+        status: "ok",
+        algorithms: OrderRouter::supported(),
+        health: h,
+        running_executions: running,
+    }))
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PositionsResponse {
+    pub positions: HashMap<String, Position>,
+}
+
+pub async fn positions(
+    State(s): State<Arc<ServerState>>,
+) -> Result<Json<PositionsResponse>, ServerError> {
+    let g = s.app_state.position.read().await;
+    let positions = g
+        .iter()
+        .map(|(k, v)| (k.as_str().to_string(), v.clone()))
+        .collect();
+    Ok(Json(PositionsResponse { positions }))
+}
+
+pub async fn book(
+    State(s): State<Arc<ServerState>>,
+    Path(symbol): Path<String>,
+) -> Result<Json<OrderBook>, ServerError> {
+    let sym = Symbol::new(symbol);
+    let g = s.app_state.book.read().await;
+    g.get(&sym)
+        .cloned()
+        .map(Json)
+        .ok_or_else(|| ServerError::NotFound(format!("book for {sym}")))
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct StartExecRequest {
+    pub algorithm: String,
+    pub symbol: String,
+    pub intent: Intent,
+    pub target_size: Decimal,
+    #[serde(default)]
+    pub params: AlgoParams,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct StartExecResponse {
+    pub exec_id: ExecutionId,
+    pub algorithm: String,
+}
+
+pub async fn start_exec(
+    State(s): State<Arc<ServerState>>,
+    Json(req): Json<StartExecRequest>,
+) -> Result<Json<StartExecResponse>, ServerError> {
+    validate_algorithm_name(&req.algorithm)?;
+    let mut algo = OrderRouter::build(&req.algorithm)?;
+    let exec_id = ExecutionId::new();
+
+    let (abort_tx, abort_rx) = watch::channel(false);
+    let (progress_tx, _) = broadcast::channel::<Progress>(256);
+    // Bridge: per-algo mpsc → broadcast fan-out for WS subscribers.
+    let (algo_progress_tx, mut algo_progress_rx) = tokio::sync::mpsc::channel::<Progress>(256);
+    let bcast = progress_tx.clone();
+    tokio::spawn(async move {
+        while let Some(p) = algo_progress_rx.recv().await {
+            // Best-effort fan-out — broadcast errors mean no subscribers.
+            let _ = bcast.send(p);
+        }
+    });
+
+    let symbol = Symbol::new(req.symbol);
+    let ctx = ExecutionContext {
+        exec_id,
+        symbol,
+        intent: req.intent,
+        target_size: req.target_size,
+        params: req.params,
+        state: s.app_state.clone(),
+        batch: s.batch_sender.clone(),
+        progress: algo_progress_tx,
+        abort: abort_rx,
+    };
+
+    let algorithm_name = algo.name().to_string();
+    let join = tokio::spawn(async move { algo.run(ctx).await });
+    let handle = ExecutionHandle::new(exec_id, algorithm_name.clone(), abort_tx, progress_tx, join);
+    s.registry.insert(handle).await;
+
+    Ok(Json(StartExecResponse {
+        exec_id,
+        algorithm: algorithm_name,
+    }))
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ExecStatusResponse {
+    pub exec_id: ExecutionId,
+    pub algorithm: String,
+    pub status: ExecutionStatus,
+    pub report: Option<ExecutionReport>,
+    pub error: Option<String>,
+}
+
+pub async fn get_exec(
+    State(s): State<Arc<ServerState>>,
+    Path(id): Path<String>,
+) -> Result<Json<ExecStatusResponse>, ServerError> {
+    let exec_id = parse_exec_id(&id)?;
+    let entry = s
+        .registry
+        .get(&exec_id)
+        .await
+        .ok_or_else(|| ServerError::NotFound(id.clone()))?;
+    let mut h = entry.write().await;
+    // Poll the join handle without blocking — if the algo finished, capture
+    // the result and update status.
+    if h.status == ExecutionStatus::Running {
+        // Gemini PR-7 review: avoid a race where one request takes the join
+        // handle and another sees `join == None && status == Running`. Move
+        // status to `Finalizing` *first* (still inside the write lock), then
+        // take the handle and await it.
+        let finished_handle = match h.join.as_ref() {
+            Some(join) if join.is_finished() => {
+                h.status = ExecutionStatus::Finalizing;
+                h.join.take()
+            }
+            _ => None,
+        };
+        if let Some(handle) = finished_handle {
+            match handle.await {
+                Ok(Ok(report)) => {
+                    h.status = if report.aborted {
+                        ExecutionStatus::Aborted
+                    } else {
+                        ExecutionStatus::Completed
+                    };
+                    h.final_report = Some(report);
+                }
+                Ok(Err(e)) => {
+                    h.status = ExecutionStatus::Failed;
+                    h.final_error = Some(e.to_string());
+                }
+                Err(je) => {
+                    h.status = ExecutionStatus::Failed;
+                    h.final_error = Some(format!("join error: {je}"));
+                }
+            }
+        }
+    }
+    Ok(Json(ExecStatusResponse {
+        exec_id: h.exec_id,
+        algorithm: h.algorithm.clone(),
+        status: h.status,
+        report: h.final_report.clone(),
+        error: h.final_error.clone(),
+    }))
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CancelExecResponse {
+    pub exec_id: ExecutionId,
+    pub abort_signaled: bool,
+}
+
+pub async fn cancel_exec(
+    State(s): State<Arc<ServerState>>,
+    Path(id): Path<String>,
+) -> Result<Json<CancelExecResponse>, ServerError> {
+    let exec_id = parse_exec_id(&id)?;
+    let entry = s
+        .registry
+        .get(&exec_id)
+        .await
+        .ok_or_else(|| ServerError::NotFound(id.clone()))?;
+    let h = entry.read().await;
+    let _ = h.abort.send(true);
+    Ok(Json(CancelExecResponse {
+        exec_id,
+        abort_signaled: true,
+    }))
+}
+
+fn parse_exec_id(s: &str) -> Result<ExecutionId, ServerError> {
+    use std::str::FromStr;
+    uuid::Uuid::from_str(s)
+        .map(ExecutionId)
+        .map_err(|e| ServerError::BadRequest(format!("invalid exec_id: {e}")))
+}

--- a/executor/crates/executor-server/src/state.rs
+++ b/executor/crates/executor-server/src/state.rs
@@ -1,0 +1,52 @@
+//! `ServerState` — shared bag passed via axum's `with_state`.
+//!
+//! Wraps the `AppState` (book/position/...), the `BatchSender` used by all
+//! algorithms, the `HlClient` (Mock or Real), the `Signer`, and the
+//! `ExecutionRegistry` of running executions.
+
+use std::sync::Arc;
+
+use executor_core::state::AppState;
+use executor_hl::batch_sender::{BatchSender, BatchSenderHandle};
+use executor_hl::hl_client::HlClient;
+use executor_hl::signer::Signer;
+
+use crate::registry::ExecutionRegistry;
+
+/// Server-side state. `Arc<ServerState>` is shared via `with_state`.
+pub struct ServerState {
+    pub app_state: Arc<AppState>,
+    pub hl_client: Arc<dyn HlClient>,
+    pub signer: Arc<dyn Signer>,
+    pub batch_sender: BatchSender,
+    pub batch_handle: tokio::sync::Mutex<Option<BatchSenderHandle>>,
+    pub registry: ExecutionRegistry,
+}
+
+impl ServerState {
+    pub fn new(
+        app_state: Arc<AppState>,
+        hl_client: Arc<dyn HlClient>,
+        signer: Arc<dyn Signer>,
+        batch_sender: BatchSender,
+        batch_handle: BatchSenderHandle,
+    ) -> Self {
+        Self {
+            app_state,
+            hl_client,
+            signer,
+            batch_sender,
+            batch_handle: tokio::sync::Mutex::new(Some(batch_handle)),
+            registry: ExecutionRegistry::new(),
+        }
+    }
+}
+
+impl std::fmt::Debug for ServerState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ServerState")
+            .field("app_state", &self.app_state)
+            .field("registry", &self.registry)
+            .finish_non_exhaustive()
+    }
+}

--- a/executor/crates/executor-server/src/ws.rs
+++ b/executor/crates/executor-server/src/ws.rs
@@ -1,0 +1,86 @@
+//! WS handler streaming `Progress` events for one execution.
+//!
+//! Subscribers join the broadcast channel held by the `ExecutionHandle`. A
+//! lagged receive (slow consumer) closes the WS — the client should
+//! reconnect and replay if needed.
+
+use std::sync::Arc;
+
+use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
+use axum::extract::Path;
+use axum::extract::State;
+use futures::StreamExt;
+use tokio::sync::broadcast::error::RecvError;
+
+use crate::error::ServerError;
+use crate::state::ServerState;
+
+pub async fn progress_ws(
+    State(state): State<Arc<ServerState>>,
+    Path(id): Path<String>,
+    ws: WebSocketUpgrade,
+) -> Result<axum::response::Response, ServerError> {
+    let exec_id = parse_exec_id(&id)?;
+    let entry = state
+        .registry
+        .get(&exec_id)
+        .await
+        .ok_or_else(|| ServerError::NotFound(id.clone()))?;
+    let progress = entry.read().await.progress.clone();
+    Ok(ws.on_upgrade(move |socket| async move {
+        if let Err(e) = run_socket(socket, progress).await {
+            tracing::warn!(?e, "ws closed with error");
+        }
+    }))
+}
+
+async fn run_socket(
+    socket: WebSocket,
+    progress: tokio::sync::broadcast::Sender<executor_core::intent::Progress>,
+) -> anyhow::Result<()> {
+    let (mut sender, mut receiver) = socket.split();
+    let mut rx = progress.subscribe();
+    let mut closed = false;
+    while !closed {
+        tokio::select! {
+            evt = rx.recv() => {
+                match evt {
+                    Ok(p) => {
+                        let payload = serde_json::to_string(&p)?;
+                        if futures::SinkExt::send(&mut sender, Message::Text(payload.into()))
+                            .await
+                            .is_err()
+                        {
+                            closed = true;
+                        }
+                    }
+                    Err(RecvError::Closed) => {
+                        closed = true;
+                    }
+                    Err(RecvError::Lagged(n)) => {
+                        tracing::warn!(skipped = n, "ws subscriber lagged, closing");
+                        closed = true;
+                    }
+                }
+            }
+            // Drain client-side pings/pongs; if the client closes, we exit.
+            client = receiver.next() => {
+                match client {
+                    Some(Ok(Message::Close(_))) | None => {
+                        closed = true;
+                    }
+                    Some(Ok(_)) => {}
+                    Some(Err(_)) => closed = true,
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn parse_exec_id(s: &str) -> Result<executor_core::intent::ExecutionId, ServerError> {
+    use std::str::FromStr;
+    uuid::Uuid::from_str(s)
+        .map(executor_core::intent::ExecutionId)
+        .map_err(|e| ServerError::BadRequest(format!("invalid exec_id: {e}")))
+}

--- a/executor/crates/executor-server/tests/integration_rest.rs
+++ b/executor/crates/executor-server/tests/integration_rest.rs
@@ -1,0 +1,273 @@
+//! End-to-end integration tests against the axum app.
+//!
+//! Spins up the `Router` directly via `tower::ServiceExt::oneshot` so we
+//! avoid binding a real socket. Uses MockHlClient + MockSigner.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::body::{to_bytes, Body};
+use axum::http::{Request, StatusCode};
+use rust_decimal_macros::dec;
+use serde_json::json;
+use tower::ServiceExt;
+
+use executor_core::state::{AppState, BookLevel, OrderBook, Position};
+use executor_core::symbol::Symbol;
+use executor_hl::batch_sender::{spawn_batch_sender, BatchSenderConfig};
+use executor_hl::hl_client::MockHlClient;
+use executor_hl::signer::MockSigner;
+use executor_server::{build_app, ServerState};
+
+fn lvl(px: rust_decimal::Decimal, sz: rust_decimal::Decimal) -> BookLevel {
+    BookLevel { px, sz, n: 1 }
+}
+
+async fn build_state_with_seed() -> (Arc<ServerState>, Arc<MockHlClient>) {
+    let app_state = Arc::new(AppState::new());
+    {
+        let mut b = app_state.book.write().await;
+        b.insert(
+            Symbol::new("BTC"),
+            OrderBook {
+                bids: vec![lvl(dec!(49999), dec!(10))],
+                asks: vec![lvl(dec!(50001), dec!(10))],
+                ts: Some(chrono::Utc::now()),
+            },
+        );
+    }
+    {
+        let mut p = app_state.position.write().await;
+        p.insert(
+            Symbol::new("BTC"),
+            Position {
+                size: dec!(0),
+                ..Default::default()
+            },
+        );
+    }
+    let mock_hl = Arc::new(MockHlClient::new());
+    let signer = Arc::new(MockSigner::new());
+    let (batch_sender, batch_handle) = spawn_batch_sender(
+        mock_hl.clone(),
+        BatchSenderConfig {
+            flush_interval: Duration::from_millis(20),
+            max_batch_size: 10,
+        },
+    );
+    let state = Arc::new(ServerState::new(
+        app_state,
+        mock_hl.clone(),
+        signer,
+        batch_sender,
+        batch_handle,
+    ));
+    (state, mock_hl)
+}
+
+#[tokio::test]
+async fn health_returns_ok() {
+    let (state, _) = build_state_with_seed().await;
+    let app = build_app(state);
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/v1/health")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = to_bytes(resp.into_body(), 64 * 1024).await.unwrap();
+    let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(v["status"], "ok");
+    assert!(v["algorithms"].as_array().unwrap().len() >= 4);
+}
+
+#[tokio::test]
+async fn book_returns_seeded_orderbook() {
+    let (state, _) = build_state_with_seed().await;
+    let app = build_app(state);
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/v1/book/BTC")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = to_bytes(resp.into_body(), 64 * 1024).await.unwrap();
+    let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(v["bids"][0]["px"], "49999");
+    assert_eq!(v["asks"][0]["px"], "50001");
+}
+
+#[tokio::test]
+async fn book_missing_symbol_404() {
+    let (state, _) = build_state_with_seed().await;
+    let app = build_app(state);
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/v1/book/UNKNOWN")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn start_exec_unknown_algorithm_400() {
+    let (state, _) = build_state_with_seed().await;
+    let app = build_app(state);
+    let body = json!({
+        "algorithm": "vwap",
+        "symbol": "BTC",
+        "intent": "open",
+        "target_size": "0.1",
+        "params": {}
+    });
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/exec")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn start_exec_market_returns_id_and_can_be_cancelled() {
+    let (state, _mock) = build_state_with_seed().await;
+    let app = build_app(state);
+
+    // Start a market execution. With no fills coming, it'll spin until
+    // max_attempts → aborted. We immediately cancel to force exit.
+    let req_body = json!({
+        "algorithm": "market",
+        "symbol": "BTC",
+        "intent": "open",
+        "target_size": "0.1",
+        "params": {
+            "max_book_age_ms": 0,
+            "slice_timeout_ms": 50,
+            "max_attempts": 1
+        }
+    });
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/exec")
+                .header("content-type", "application/json")
+                .body(Body::from(req_body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = to_bytes(resp.into_body(), 64 * 1024).await.unwrap();
+    let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let exec_id = v["exec_id"].as_str().unwrap().to_string();
+    assert_eq!(v["algorithm"], "MARKET");
+
+    // Cancel it.
+    let cancel_resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/v1/exec/{exec_id}/cancel"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(cancel_resp.status(), StatusCode::OK);
+
+    // Give it a moment to settle, then poll status.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    let status_resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(format!("/v1/exec/{exec_id}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(status_resp.status(), StatusCode::OK);
+    let body = to_bytes(status_resp.into_body(), 64 * 1024).await.unwrap();
+    let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let status = v["status"].as_str().unwrap();
+    assert!(
+        matches!(status, "aborted" | "completed" | "running" | "failed"),
+        "unexpected status: {status}"
+    );
+}
+
+#[tokio::test]
+async fn cancel_unknown_exec_404() {
+    let (state, _) = build_state_with_seed().await;
+    let app = build_app(state);
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/exec/00000000-0000-0000-0000-000000000000/cancel")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn get_exec_invalid_id_400() {
+    let (state, _) = build_state_with_seed().await;
+    let app = build_app(state);
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/v1/exec/not-a-uuid")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn positions_returns_seeded() {
+    let (state, _) = build_state_with_seed().await;
+    let app = build_app(state);
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/v1/positions")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = to_bytes(resp.into_body(), 64 * 1024).await.unwrap();
+    let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert!(v["positions"]["BTC"].is_object());
+}


### PR DESCRIPTION
## Summary
- 6 REST endpoints + 1 WS endpoint, wiring all 4 algorithms (PR-3〜PR-6) to network
- ServerState + OrderRouter + ExecutionRegistry (with abort_all for PR-8)
- 16 tests (7 unit + 8 integration via tower::ServiceExt::oneshot, no socket bind)

## Gemini partner review (round 1)
**Verdict** (`flash-lite`): solid axum code; addressed:
- get_exec race → `ExecutionStatus::Finalizing` intermediate state
- Internal error leaking → server-side log + generic client message
- emergency_stop readiness → `ExecutionRegistry::abort_all()` added

Recorded in SurrealDB `review_log` with tags `pr-7,executor-server,axum,gemini-review`.

## Test plan
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace --all-features` — **111/111 pass** (56 algo + 22 core + 17 hl + 16 server)
- [x] `scripts/check_ci_local.sh` — All checks passed locally

## REST endpoints
| Method | Path | Purpose |
|---|---|---|
| GET | /v1/health | algorithm list + AppState health |
| GET | /v1/positions | current positions |
| GET | /v1/book/{symbol} | top-of-book snapshot |
| POST | /v1/exec | start an execution |
| GET | /v1/exec/{id} | status + final report |
| POST | /v1/exec/{id}/cancel | abort one execution |

## WS endpoint
| Method | Path | Purpose |
|---|---|---|
| GET | /v1/exec/{id}/ws | stream Progress events |

## Run locally
```bash
EXECUTOR_BIND=127.0.0.1:8085 cargo run -p executor-server --release
curl localhost:8085/v1/health
```

## Next: PR-8 emergency_stop + Python connector + dry-run integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)