### PR TITLE
docs(executor): 日本語ドキュメント整備 (13 files, 2348 lines)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ Hyperliquid (HIP-3 / Trade[XYZ]) 上の **米株指数 perpetual** と **オー�
 - [x] **LiveEngine dry-run** (BacktestEngine と同一 Strategy ABC を継承)
 - [x] **Analytics dashboard** (marimo + altair, Sharpe/Sortino/DD 等 8 KPI + KPI カード + 自由探索)
 - [x] CI (ruff/format/mypy/pytest), **61/61 tests pass**
-- [ ] Phase 3 (実発注 + EIP-712 鍵管理 + キル スイッチ)
+- [x] **Rust executor 80% プロトタイプ完了** — 4 algorithms (MARKET / PASSIVE / TWAP / MM) + axum REST+WS + Python connector + CLI ([`docs/executor/`](docs/executor/README.md))
+- [ ] Phase 3.5 (鍵管理 + EIP-712 signer + Real HL POST + Auth レイヤ)
 
 ## Quick start
 ```bash
@@ -34,6 +35,11 @@ python scripts/audit_quality.py                        # → docs/audit/D_qualit
 # GUI
 marimo edit notebooks/dashboard.py                     # 編集モード
 marimo run  notebooks/dashboard.py                     # 発表モード
+
+# Rust executor (keyless mock 構成で動作確認)
+cd executor && cargo run -p executor-server --release  # port 8085 で起動
+cargo run -p executor-cli -- health                    # 別 terminal で疎通確認
+# 詳細: docs/executor/README.md
 ```
 
 ## アーキテクチャ

--- a/docs/executor/README.md
+++ b/docs/executor/README.md
@@ -1,0 +1,100 @@
+# Rust Executor ドキュメント
+
+Hyperliquid (HIP-3 / Trade[XYZ]) への注文執行レイヤ (`executor/` 以下) のドキュメント集。
+2026-05-04 に PR-1 〜 PR-8 の 8 PR で **80 % プロトタイプ** が完成した。
+
+> **80 % プロトタイプとは**:
+> 鍵管理 (`secrecy` / `zeroize` 統合, 実 EIP-712 signer) と HL への実 POST `/exchange` 以外
+> は全て実装済み。`MockHlClient` + `MockSigner` で keyless にエンドツーエンド動作する。
+
+## 主要ドキュメント
+
+| 区分 | ファイル | 内容 |
+|---|---|---|
+| **設計** | [`../specs/2026-05-04-rust-executor-design.md`](../specs/2026-05-04-rust-executor-design.md) | 設計仕様 v2 (Gemini deep review 反映) — レイテンシ目標, cancel 戦略, nonce 管理, split-lock 等 |
+| 全体像 | [`architecture.md`](architecture.md) | crate 構成, データフロー, 責務分担 |
+| **API** | [`api/rest.md`](api/rest.md) | REST 7 endpoint の全仕様 |
+| | [`api/websocket.md`](api/websocket.md) | `/v1/exec/{id}/ws` Progress イベント |
+| **アルゴリズム** | [`algorithms/market.md`](algorithms/market.md) | MARKET — taker IOC + slippage cap |
+| | [`algorithms/passive_follow.md`](algorithms/passive_follow.md) | PASSIVE_FOLLOW — maker ALO at touch |
+| | [`algorithms/twap.md`](algorithms/twap.md) | TWAP — 時間スライス |
+| | [`algorithms/market_make.md`](algorithms/market_make.md) | MARKET_MAKE — target 駆動 2-sided ALO |
+| **連携** | [`connector/python.md`](connector/python.md) | Python から executor を呼び出す (`src/executor/`) |
+| | [`cli.md`](cli.md) | `executor-cli` バイナリ — 7 サブコマンド |
+| **運用** | [`operations/dev-setup.md`](operations/dev-setup.md) | 開発環境 / ビルド / テスト |
+| | [`operations/deployment.md`](operations/deployment.md) | 本番投入前チェックリスト |
+| | [`operations/troubleshooting.md`](operations/troubleshooting.md) | よくあるエラーと対処 |
+| **状態** | [`status.md`](status.md) | 実装済み / 未実装 / 残タスク (Phase 3.5 以降) |
+
+## 30 秒で全体像
+
+```
+┌──────────────────────┐                       ┌──────────────────────┐
+│ Python 戦略レイヤ      │  HTTP+WS (port 8085) │ executor-server      │
+│ (src/l3_strategy/...)│ ────────────────────▶ │ (axum, Rust)         │
+│ + src/executor       │                       │                      │
+│   (Python connector) │                       │  ├─ OrderRouter      │
+└──────────────────────┘                       │  ├─ ExecutionRegistry│
+                                               │  └─ AppState 共有    │
+                                               │                      │
+                                               │  ┌────────────────┐  │
+                                               │  │ executor-algo  │  │
+                                               │  │ MARKET/PASSIVE │  │
+                                               │  │ /TWAP/MM       │  │
+                                               │  └─────┬──────────┘  │
+                                               │        │             │
+                                               │  ┌─────▼──────────┐  │
+                                               │  │ executor-hl    │  │
+                                               │  │ BatchSender    │  │
+                                               │  │ (100ms flush)  │  │
+                                               │  │ TokenBucket    │  │
+                                               │  │ HlClient       │  │
+                                               │  │ Signer         │  │
+                                               │  └─────┬──────────┘  │
+                                               └────────┼─────────────┘
+                                                        │
+                                                        ▼
+                                              ┌──────────────────┐
+                                              │ Hyperliquid REST │
+                                              │ POST /exchange   │
+                                              └──────────────────┘
+```
+
+## 5 分で動かす
+
+```bash
+# 1. ビルド
+cd executor
+cargo build -p executor-server --release
+
+# 2. 起動 (MockHlClient + MockSigner なので鍵不要)
+EXECUTOR_BIND=127.0.0.1:8085 cargo run -p executor-server --release
+
+# 3. ヘルスチェック
+curl localhost:8085/v1/health | jq
+
+# 4. CLI から発注 (mock なので何も実取引はしない)
+cargo run -p executor-cli -- exec --algo market --symbol BTC --intent open --size 0.1
+```
+
+詳細は [`operations/dev-setup.md`](operations/dev-setup.md) を参照。
+
+## 設計上の重要ルール
+
+- **責務単一**: 各アルゴリズム = 独立関数。executor 全体 = HL 発注のみ。
+- **Cancel 戦略は cloid 一括 cancel**: nonce 無効化は in-flight しか弾かないため板上指値は残る (Gemini レビュー指摘)。
+- **`#![forbid(unsafe_code)]`**: workspace 全 crate で適用。
+- **`rust_decimal` で価格・サイズ**: f64 sign 精度問題回避。
+- **BatchSender は 100 ms フラッシュ**: HL ≦ 1 POST/100ms ガイダンス遵守。
+- **Cancel before Abort** (`/v1/emergency_stop`): 板上 order 先に止め, 後で algo 停止。
+
+## テスト集計 (2026-05-04 時点)
+
+| 区分 | 数 |
+|---|---|
+| Rust unit + integration | 113 |
+| Python (CI 対象) | 79 |
+| Python (live e2e, marker `live`) | 5 |
+| **合計** | **197** |
+
+`cargo fmt` / `cargo clippy -D warnings` / `ruff` / `mypy` / `scripts/check_ci_local.sh` 全てクリーン。

--- a/docs/executor/algorithms/market.md
+++ b/docs/executor/algorithms/market.md
@@ -1,0 +1,138 @@
+# MARKET アルゴリズム
+
+> 実装: [`executor/crates/executor-algo/src/market.rs`](../../../executor/crates/executor-algo/src/market.rs)
+> PR: [#60](https://github.com/howlrs/diff-old-new/pull/60)
+
+## 役割
+
+**taker (テイカー) スタイルの即時執行**。slippage 上限つきの IOC (Immediate-or-Cancel) 指値を投入し,
+部分約定時は残量で再投入。`max_attempts` 回試行してもまだ残量がある場合は abort。
+
+ユーザー要望「現在の A ポジションを即座に解除したい」「成り行きで B 銘柄を 100 取りたい」に対応する基本アルゴリズム。
+
+## 動作フロー
+
+```
+1. ctx.params から MarketParams を抽出 (validation 含む)
+2. AppState.position から現在ポジション snapshot
+3. resolve_side_and_size(intent, target_size, current) で side + abs_size 算出
+4. while remaining > 0:
+   a. abort 信号確認
+   b. attempts > max_attempts なら abort 終了
+   c. AppState.book から book snapshot
+   d. ensure_book_fresh() で stale 検出 (max_book_age_ms)
+   e. taker_limit_price() で slippage 込み limit_px 算出
+   f. 新 cloid 生成 → BatchSender.enqueue(Place(IOC OrderIntent))
+   g. collect_own_fills() で slice_timeout_ms まで fill 待機
+   h. 新規 fill を all_fills に追加, remaining 減算
+5. build_report() → Progress::Completed 送出
+```
+
+## Intent と side / size の決定
+
+`resolve_side_and_size(intent, target_size, current_size)` の挙動:
+
+| Intent | target_size の符号 | 動作 |
+|---|---|---|
+| `Open` | + | side=Long, abs_size = `|target_size|` |
+| `Open` | - | side=Short, abs_size = `|target_size|` |
+| `Open` | 0 | **エラー** (`InvalidParams: Open with target_size = 0`) |
+| `SetTarget` | delta = target − current ≠ 0 | side = sign(delta), abs_size = `|delta|` |
+| `SetTarget` | delta = 0 | **エラー** (`InvalidParams: already at target`) |
+| `Close` | (current = 0) | **エラー** (`InvalidParams: no position to close`) |
+| `Close` | target_size = 0 | side = 反対側, abs_size = `|current|` (全クローズ) |
+| `Close` | target_size > 0 | side = 反対側, abs_size = `min(target_size, |current|)` (部分クローズ) |
+
+> **Close + target_size > 0 のセマンティクス**: 「current の符号と逆方向に target_size 分まで動かす (上限 |current|)」。
+> 例: current=-2.0, target_size=1.0 → side=Long, abs_size=1.0 (短ポジを 1.0 だけ買い戻し → 残 short 1.0)。
+
+## AlgoParams
+
+| key | 型 | デフォルト | 説明 |
+|---|---|---|---|
+| `max_slippage_bps` | string→Decimal | `"20"` | IOC 指値の slippage cap (basis points) |
+| `max_attempts` | u32 | `5` | slice 試行の最大回数。超過で aborted=true で終了 |
+| `slice_timeout_ms` | u32 | `1500` | 1 slice あたりの fill 待機 deadline |
+| `max_book_age_ms` | u32 | `500` | book.ts がこれより古ければ stale としてエラー (`0` で無効化) |
+| `reduce_only` | bool | `false` | OrderIntent の reduce_only フラグ |
+
+`max_book_age_ms = 0` は `tokio::time::pause()` を使う unit test 用。実運用では必ず正の値。
+
+## limit price 算出 (`taker_limit_price`)
+
+```
+Long (買いたい):  limit_px = best_ask * (1 + max_slippage_bps / 10000)
+Short (売りたい): limit_px = best_bid * (1 - max_slippage_bps / 10000)
+```
+
+例: best_ask = 100, slippage = 50bps → limit_px = 100.5。
+HL は IOC で limit を超えなければ部分約定 / 不成立を返す。
+
+## 終了条件
+
+| 条件 | 結果 |
+|---|---|
+| `remaining == 0` | `aborted=false`, full fill |
+| abort signal | `aborted=true`, `abort_reason="aborted by caller"` |
+| `attempts > max_attempts` | `aborted=true`, `abort_reason="max_attempts (N) exceeded with M remaining"` |
+
+## ライブで起きうるエラー
+
+| エラーメッセージ | 原因 | 対応 |
+|---|---|---|
+| `market: empty asks (no best ask)` | book に asks 行が無い | symbol 名 typo / WS 未接続 |
+| `market: empty bids (no best bid)` | book に bids 行が無い | 同上 |
+| `market: book stale (XXXms > YYYms)` | book.ts が古い | WS 再接続待ち / `max_book_age_ms` 緩和 |
+| `Open with target_size = 0` | 仕様エラー | クライアント側を修正 |
+| `derived size <= 0` | 内部矛盾 (通常出ない) | バグ報告 |
+
+## ユースケース別パラメータ例
+
+### A. 全クローズを最速で
+
+```json
+{
+  "algorithm":  "market",
+  "symbol":     "BTC",
+  "intent":     "close",
+  "target_size":"0",
+  "params": { "max_slippage_bps": "30", "max_attempts": 3, "slice_timeout_ms": 1000 }
+}
+```
+
+`reduce_only:true` を加えると, ヘッジ建て時の意図しない逆ポジ防止に。
+
+### B. 100 BTC を素早く新規 long
+
+```json
+{
+  "algorithm":  "market",
+  "symbol":     "BTC",
+  "intent":     "open",
+  "target_size":"100.0",
+  "params": { "max_slippage_bps": "50", "max_attempts": 10, "slice_timeout_ms": 2000 }
+}
+```
+
+slippage 緩めて max_attempts 多めに。
+
+## テスト (`market::tests`)
+
+20 ケース:
+
+- 7 件: side resolution (`resolve_side_open_long` 等)
+- 2 件: limit price 計算 (long/short slippage)
+- 4 件: book freshness (stale/recent/none/missing-ts)
+- 2 件: full fill via Mock (open long / close short)
+- 2 件: abort 経路 (signal / max_attempts)
+- 2 件: partial fill → top-up (60% → remainder, 50% → 50% → full の chain)
+
+`tokio::time::pause()` + `tokio::time::advance()` で実時間に依存しない。
+`MockHlClient::placed_calls()` で発信内容を検証。
+
+## 関連
+
+- [Algorithm trait + ExecutionContext](../architecture.md)
+- [REST `POST /v1/exec`](../api/rest.md)
+- [PASSIVE_FOLLOW](passive_follow.md) — taker でなく maker で同じ目的
+- [TWAP](twap.md) — 時間分散して MARKET / PASSIVE を呼ぶ

--- a/docs/executor/algorithms/market_make.md
+++ b/docs/executor/algorithms/market_make.md
@@ -1,0 +1,194 @@
+# MARKET_MAKE アルゴリズム
+
+> 実装: [`executor/crates/executor-algo/src/market_make.rs`](../../../executor/crates/executor-algo/src/market_make.rs)
+> PR: [#63](https://github.com/howlrs/diff-old-new/pull/63)
+
+## 役割
+
+**target inventory 駆動の 2-sided ALO market making**。bid と ask を同時に出して
+スプレッドを獲得しつつ, **目標ポジション** から逸脱したら quote サイズを skew (傾ける) して
+inventory を target に近付ける。
+
+ユーザー要望「**B 銘柄を market make で 100 long position make したい**」「**market make でポジション解消**」
+が該当。target_size に最終的にしたい signed position を指定する。
+
+## 動作フロー
+
+```
+loop:
+  1. abort 信号 → 両 quote cancel → aborted で return
+  2. started_instant.elapsed() >= max_total → 両 quote cancel → 最終位置で aborted/completed 判定
+  3. drain_new_fills で fill 反映 + Progress::SliceFilled
+     fill が起きた cloid を bid/ask Quote から落とす (次 iter で再 quote)
+  4. AppState.position.size から current 取得 → delta = target - current
+  5. |delta| <= target_tolerance_size なら両 quote cancel → break (完了)
+  6. AppState.book snapshot → ensure_book_fresh → mid 取得
+  7. quote_prices(mid, spread_bps_each_side) → (bid_px, ask_px)
+  8. quote_sizes(delta, quote_size) → (bid_sz, ask_sz)  ※skew
+  9. needs_repost(bid_quote, bid_px, bid_sz, repost_bps_threshold) なら:
+       既存 bid cancel → 新 bid を ALO で enqueue
+     ask 側も同様
+  10. Progress::Heartbeat
+  11. tokio::time::sleep(repost_poll)
+```
+
+## quote price の決定 (`quote_prices`)
+
+```
+factor   = spread_bps_each_side / 10000
+bid_px   = mid * (1 - factor)
+ask_px   = mid * (1 + factor)
+```
+
+例: mid=50000, spread_bps_each_side=10 → bid=49950, ask=50050。
+
+## quote size の skew (`quote_sizes`)
+
+```
+delta = target - current  (positive = もっと long に振りたい)
+cap   = quote_size * 2
+
+delta == 0:        bid_sz = quote_size, ask_sz = quote_size  (中立)
+delta > 0:         bid_sz = min(quote_size + delta, cap)
+                   ask_sz = max(quote_size - delta, 0)
+delta < 0:         bid_sz = max(quote_size - |delta|, 0)
+                   ask_sz = min(quote_size + |delta|, cap)
+```
+
+| delta | bid_sz | ask_sz | 意味 |
+|---|---|---|---|
+| 0 | quote_size | quote_size | 中立 (両側等量) |
+| +0.5 (quote_size=1) | 1.5 | 0.5 | bid 厚く, ask 薄く |
+| +1.0 (quote_size=1) | 2.0 (cap) | 0.0 | bid のみ. ask 撤退 |
+| +5.0 (quote_size=1) | 2.0 (cap) | 0.0 | 同上. cap で頭打ち |
+| -0.7 (quote_size=1) | 0.3 | 1.7 | ask 厚く |
+
+`ask_sz=0` のとき ask 側は post せず, BatchSender に何も送らない (cancel だけ)。
+
+## repost 判定 (`needs_repost`)
+
+```rust
+match existing {
+    None => new_sz > 0,                          // 初回 → 立てる (ただし sz>0 のときのみ)
+    Some(_) if new_sz <= 0 => true,              // 撤退要求 → cancel
+    Some(_) if old_sz != new_sz => true,         // size 変化 → repost
+    Some(_) => moved_bps > repost_bps_threshold, // mid 移動が閾値超
+}
+```
+
+## AlgoParams
+
+| key | 型 | デフォルト | 説明 |
+|---|---|---|---|
+| `quote_size` | string→Decimal | **必須** | 各サイドのベースサイズ |
+| `spread_bps_each_side` | string→Decimal | `"10"` | bid/ask 半スプレッド (bps) |
+| `repost_bps_threshold` | string→Decimal | `"2"` | mid がこれだけ動いたら repost |
+| `max_total_ms` | u32 | `300000` | 全体時間 (5 分) |
+| `repost_poll_ms` | u32 | `250` | poll 周期 |
+| `max_book_age_ms` | u32 | `500` | stale 検出 (0 で無効化) |
+| `target_tolerance_size` | string→Decimal | `"0"` | `|target - current| ≤ tolerance` で完了 |
+
+> **注意 (Gemini PR-6 review 反映)**:
+> `repost_bps_threshold = 0` は "mid 変化のたび cancel/repost" となり HL レート制限を消費しがち。
+> `tracing::warn!` ログで警告するが, error は返さない。本番では ≥1 推奨。
+
+## 既知の制約 (PR-6 doc に明記)
+
+1. **`all_fills` は無限拡張**: 長時間 MM 用途では ~1 時間ごとに execution をローテーション推奨,
+   または disk 永続化するラッパーを用意 (将来課題)
+2. **`BatchSender::enqueue` の Err は fatal**: channel closed = flusher 死 → 復旧不能なので
+   `AlgoError::HyperliquidError` で abort
+
+## 終了条件
+
+| 条件 | 結果 |
+|---|---|
+| `|target - current| <= target_tolerance_size` | `aborted=false` |
+| abort signal | `aborted=true` |
+| `total_duration_ms` 経過 | `aborted = (|target-current| > tolerance)` |
+
+## ユースケース
+
+### A. 100 BTC 目標 (current 0 から開始)
+
+```json
+{
+  "algorithm":   "market_make",
+  "symbol":      "BTC",
+  "intent":      "set_target",
+  "target_size": "100.0",
+  "params": {
+    "quote_size":           "0.5",
+    "spread_bps_each_side": "10",
+    "repost_bps_threshold": "3",
+    "max_total_ms":         86400000,
+    "repost_poll_ms":       250
+  }
+}
+```
+
+quote_size=0.5 で常時 0.5 BTC 出しつつ, current=0 なら delta=100 (>>quote_size=0.5)
+→ bid=1.0 (cap), ask=0.0 で **bid 1 本のみ** 出す状態が続く。
+current が 100 に近付くにつれ ask が出始め, 100 で両側等量に。
+
+### B. ポジション中立化 (target=0, current=+50)
+
+```json
+{
+  "algorithm":   "market_make",
+  "symbol":      "ETH",
+  "intent":      "set_target",
+  "target_size": "0",
+  "params": {
+    "quote_size": "0.5",
+    "spread_bps_each_side": "8",
+    "target_tolerance_size": "0.1",
+    "max_total_ms": 7200000
+  }
+}
+```
+
+current=+50 → delta=-50 → bid=0, ask=1.0 (cap) で売り 1 本。0.1 までに収束したら終了。
+
+### C. tight spread でリベート狙い
+
+```json
+{
+  "params": {
+    "quote_size":           "0.1",
+    "spread_bps_each_side": "1",
+    "repost_bps_threshold": "1"
+  }
+}
+```
+
+ALO は post-only なので cross したら拒否される (taker fill なし)。
+ただし `repost_bps_threshold=1` だと頻繁に repost してレート制限を消費する点に注意。
+
+## エラー
+
+| エラー | 原因 |
+|---|---|
+| `quote_size is required` | params 必須 |
+| `quote_size must be > 0` / `spread_bps_each_side must be >= 0` | validation |
+| `market_make: empty book (no mid)` | book に bid/ask どちらかが無い |
+| `book stale (...)` | WS 切断中 |
+| `batch enqueue: ...` | flusher dead (fatal) |
+
+## テスト (`market_make::tests`)
+
+14 ケース:
+
+- 5 件: quote price/size 計算 (中立, long skew, short skew, cap, neutral)
+- 4 件: needs_repost (初回, size 変化, threshold 内, threshold 超)
+- 1 件: from_algo_requires_quote_size
+- 4 件: integration via MockHlClient
+  - 中立 (delta=0) で両側 ALO at mid±10bps
+  - 上方 skew (delta=+0.05, quote_size=0.1 → bid_sz=0.15, ask_sz=0.05)
+  - target reach で exit
+  - max_total timeout で cancel される
+
+## 関連
+
+- [PASSIVE_FOLLOW](passive_follow.md) — 1 サイドのみ
+- [MARKET](market.md) / [TWAP](twap.md)

--- a/docs/executor/algorithms/passive_follow.md
+++ b/docs/executor/algorithms/passive_follow.md
@@ -1,0 +1,144 @@
+# PASSIVE_FOLLOW アルゴリズム
+
+> 実装: [`executor/crates/executor-algo/src/passive_follow.rs`](../../../executor/crates/executor-algo/src/passive_follow.rs)
+> PR: [#61](https://github.com/howlrs/diff-old-new/pull/61)
+
+## 役割
+
+**maker (メイカー) スタイルの執行**。常に **best bid** (long) または **best ask** (short) に
+ALO (Add-Liquidity-Only / post-only) 指値を 1 本だけ resting させ続け, 板の touch が動いたら
+個別 cancel + 即時 repost で追従する。
+
+ユーザー要望「market make で 100 long position を作りたい」「market make でポジション解消したい」
+の "market make 風 1 サイド執行" に対応 (両建て maker は [MARKET_MAKE](market_make.md) 側)。
+
+## 動作フロー
+
+```
+1. ctx.params から PassiveFollowParams 抽出
+2. AppState.position から現在ポジション snapshot
+3. resolve_side_and_size() で side + abs_size 算出 (MARKET と同じ規則)
+4. loop:
+   a. abort 信号 → 残 quote cancel → aborted で return
+   b. started_instant.elapsed() >= max_total → 残 quote cancel → aborted で return
+   c. drain_new_fills() で fill 反映 → all_fills/remaining 更新, Progress::SliceFilled 送出
+   d. remaining <= 0 なら break (完了)
+   e. AppState.book snapshot → ensure_book_fresh()
+   f. touch_for_side() で best_bid (long) / best_ask (short)
+   g. 既存 quote と price 差ありなら:
+       - 旧 cloid を CancelIntent で BatchSender enqueue
+       - 新 cloid で ALO OrderIntent を BatchSender enqueue (size = remaining)
+   h. tokio::time::sleep(repost_poll)
+5. build_report() → Progress::Completed
+```
+
+**1 タイミングに resting 注文は最大 1 本** (両側持たない)。両建て市場メイクは MARKET_MAKE 側の役割。
+
+## maker 側の touch 選択 (`touch_for_side`)
+
+```
+side = Long  (買いたい): touch = best_bid → 列に並ぶ
+side = Short (売りたい): touch = best_ask → 列に並ぶ
+```
+
+**注意**: Close-Short は `side=Long` (買い戻し) になり, **best_bid に並ぶ**。
+直感的に "売りに引っかけたい" と思いがちだが maker は反対側に立つ。
+
+## AlgoParams
+
+| key | 型 | デフォルト | 説明 |
+|---|---|---|---|
+| `max_total_ms` | u32 | `60000` | 全体 wall-clock budget。超過で abort |
+| `repost_poll_ms` | u32 | `250` | book の poll 間隔 |
+| `repost_threshold_ticks` | u32 | `0` | tick-aware 閾値 (※現状 placeholder, 0 = touch 変化で都度 repost) |
+| `max_book_age_ms` | u32 | `500` | book.ts がこれより古ければ abort (0 で無効化) |
+| `reduce_only` | bool | `false` | reduce_only flag |
+
+> **`repost_threshold_ticks` について**: 80% プロト時点では tick size を per-symbol で持っていないため
+> 実質 no-op。将来的に `executor-core::symbol` に tick metadata を入れた時点で有効化予定 (Gemini PR-4 deferred)。
+
+## repost のタイミング
+
+`current_quote = (cloid, px)` を保持し, 新 touch との差で判定:
+
+```rust
+let need_repost = match &current_quote {
+    None => true,                                  // 初回 → 立てる
+    Some((_, old_px)) => (new_touch - old_px).abs() > Decimal::ZERO,  // 任意の変化で repost
+};
+```
+
+repost = **cancel 旧 + place 新** を **同じ BatchSender に enqueue**。
+両者は次の 100 ms flush で 1 POST にまとまる。
+
+## 終了条件
+
+| 条件 | 結果 |
+|---|---|
+| `remaining <= 0` | `aborted=false`, full fill |
+| `abort signal` | `aborted=true`, `abort_reason="aborted by caller"` |
+| `started_instant.elapsed() >= max_total` | `aborted=true`, `abort_reason="max_total (...) elapsed with N remaining"` |
+
+最終 quote は abort/timeout/完了いずれの経路でも cancel される (cleanup 漏れなし)。
+
+## エラー
+
+| エラー | 原因 |
+|---|---|
+| `passive: empty bids` / `passive: empty asks` | book にこちら側の touch が存在しない |
+| `book stale (...)` | WS 切断中など |
+| `derived size <= 0` | resolve_side_and_size の 0 サイズ |
+| `batch enqueue: ...` | BatchSender flusher が dead (fatal) |
+
+## ユースケース
+
+### A. 100 BTC を maker で取得 (rebate 取りたい)
+
+```json
+{
+  "algorithm":  "passive",
+  "symbol":     "BTC",
+  "intent":     "open",
+  "target_size":"100.0",
+  "params": {
+    "max_total_ms":  3600000,
+    "repost_poll_ms": 500,
+    "max_book_age_ms": 1000
+  }
+}
+```
+
+最大 1 時間粘る。500ms 毎に板チェックして touch がずれたら cancel + repost。
+
+### B. ポジション解消 (急がない)
+
+```json
+{
+  "algorithm":  "passive",
+  "symbol":     "BTC",
+  "intent":     "close",
+  "target_size":"0",
+  "params": { "max_total_ms": 1800000 }
+}
+```
+
+reduce_only=true を併用すると, ヘッジ用途で意図しない逆ポジ作成を防げる。
+
+## テスト (`passive_follow::tests`)
+
+9 ケース:
+
+- 3 件: `touch_for_side` の long/short/empty
+- 5 件: integration via MockHlClient + watcher task で fill 模擬
+  - ALO at best_bid の検証 (price=49999)
+  - 板移動時の cancel + repost (≥2 placed + ≥1 cancelled)
+  - close-short が long で best_bid に並ぶ
+  - abort 即時
+  - max_total timeout (cancel される)
+- 1 件: partial fill + book move → 残量で repost (PR-4 round 2 で追加)
+
+## 関連
+
+- [MARKET](market.md) — 同じ目的を taker で
+- [TWAP](twap.md) — child_algo=passive で時間分散
+- [MARKET_MAKE](market_make.md) — 両建て maker (target 中立に保つ)

--- a/docs/executor/algorithms/twap.md
+++ b/docs/executor/algorithms/twap.md
@@ -1,0 +1,149 @@
+# TWAP アルゴリズム
+
+> 実装: [`executor/crates/executor-algo/src/twap.rs`](../../../executor/crates/executor-algo/src/twap.rs)
+> PR: [#62](https://github.com/howlrs/diff-old-new/pull/62)
+
+## 役割
+
+**Time-Weighted Average Price**。`abs_size` を `slice_count` 等分し, `total_duration_ms / slice_count`
+ごとに 1 slice ずつ執行する。child algorithm として `market` (taker IOC) または `passive` (maker ALO) を選べる。
+
+ユーザー要望「**現在の A ポジションを TWAP で解除してください**」がそのまま該当。
+
+## 動作フロー
+
+```
+1. ctx.params から TwapParams 抽出 (slice_count > 0, total_duration > 0 等)
+2. AppState.position から現在ポジション snapshot
+3. resolve_side_and_size() で side + abs_size 算出
+4. slice_size_base = abs_size / slice_count
+   interval       = total_duration / slice_count
+5. for slice_idx in 1..=slice_count:
+   a. abort/timeout チェック
+   b. target_at_slice = slice_size_base * slice_idx
+      (最終 slice は abs_size 丸めを吸収するため target_at_slice = abs_size)
+   c. slice_target_remaining = max(0, target_at_slice - filled_so_far)
+      (= 前 slice が under-fill していたら今 slice で取り戻す)
+   d. AppState.book snapshot → ensure_book_fresh
+   e. 旧 passive quote があれば cancel
+   f. child = Market: taker IOC を slice_target_remaining サイズで enqueue
+      child = Passive: ALO を touch に slice_target_remaining サイズで enqueue
+   g. wait = (Market: min(slice_timeout, interval)) / (Passive: interval)
+      で fill を drain しつつ poll
+   h. Progress::Heartbeat 送出
+6. 残 passive quote cancel
+7. 最終 drain_new_fills (straggler 救済)
+8. build_report (filled < abs_size なら aborted=true)
+```
+
+### 累積目標方式 (重要設計)
+
+`target_at_slice = slice_size_base * slice_idx` を使うため,
+slice N で under-fill しても slice N+1 で **累積目標まで取りに行く**。
+これで「先に fail した slice の量を捨てない」挙動になる。
+
+最終 slice (`slice_idx == slice_count`) は浮動少数の累積誤差を吸収するため
+`target_at_slice = abs_size` に固定される。
+
+## AlgoParams
+
+| key | 型 | デフォルト | 説明 |
+|---|---|---|---|
+| `slice_count` | u32 | `10` | スライス数。0 はエラー |
+| `total_duration_ms` | u32 | `60000` | 全体時間。0 はエラー |
+| `child_algo` | string | `"market"` | `"market"` / `"passive"` (`"passive_follow"` も可) |
+| `max_slippage_bps` | string→Decimal | `"20"` | child=market 時の slippage cap |
+| `slice_timeout_ms` | u32 | `1500` | child=market の 1 slice fill 待機 (interval を超える場合は interval 採用) |
+| `max_book_age_ms` | u32 | `500` | book stale 検出。`0` で無効化 (test 用途) |
+| `reduce_only` | bool | `false` | reduce_only flag |
+
+## child=market vs child=passive の違い
+
+| 観点 | child=market | child=passive |
+|---|---|---|
+| TIF | IOC | ALO (post-only) |
+| 価格 | best_ask (long) ± slippage | best_bid (long) / best_ask (short) — touch 同価 |
+| fill 期待値 | 高い (taker) | 低い (maker, スキップ slice もあり) |
+| 手数料 | テイク | リベート (HL のフィーモデル次第) |
+| under-fill 時 | 次 slice で累積取り直し | 同じく累積方式 |
+
+**MARKET_MAKE と passive child の違い**:
+- TWAP/passive: **片側 1 本のみ**, slice 区切りで再計算
+- MARKET_MAKE: **両側 2 本**, repost loop が常時稼働 (target は不変, drift で skew)
+
+## 終了条件
+
+| 条件 | 結果 |
+|---|---|
+| 全 slice 完走 + filled >= abs_size | `aborted=false`, completed |
+| 全 slice 完走 + filled < abs_size | `aborted=true`, `abort_reason="twap finished with X of Y filled"` |
+| abort signal | `aborted=true`, `abort_reason="aborted by caller"` |
+| `total_duration` 経過 | `aborted=true`, `abort_reason="total_duration (...) elapsed at slice N"` |
+
+## ユースケース
+
+### A. 1 時間 TWAP で 100 BTC 解除 (taker)
+
+```json
+{
+  "algorithm":   "twap",
+  "symbol":      "BTC",
+  "intent":      "close",
+  "target_size": "0",
+  "params": {
+    "slice_count":       60,
+    "total_duration_ms": 3600000,
+    "child_algo":        "market",
+    "max_slippage_bps":  "30"
+  }
+}
+```
+
+1 分毎に IOC を投入。
+
+### B. 10 分 TWAP で 5 BTC 取得 (maker, リベート狙い)
+
+```json
+{
+  "algorithm":   "twap",
+  "symbol":      "BTC",
+  "intent":      "open",
+  "target_size": "5.0",
+  "params": {
+    "slice_count":       10,
+    "total_duration_ms": 600000,
+    "child_algo":        "passive"
+  }
+}
+```
+
+1 分毎に ALO を 0.5 BTC ずつ. fill 不足は次 slice で取り戻し。
+
+## エラー
+
+| エラー | 原因 |
+|---|---|
+| `slice_count must be > 0` | 仕様違反 |
+| `total_duration_ms must be > 0` | 仕様違反 |
+| `child_algo must be one of ...` | 不明な child name |
+| `max_slippage_bps must be >= 0` | 負の slippage |
+| `twap: empty asks` / `twap: empty bids` | book に touch なし |
+| `book stale (...)` | WS 切断中 |
+
+## テスト (`twap::tests`)
+
+9 ケース:
+
+- 4 件: params validation (`parse_child_algo`, slice_count=0, total_duration=0, 負 slippage)
+- 5 件: integration via MockHlClient
+  - 5 slice market で full fill (5 distinct cloids)
+  - 3 slice passive (ALO at best_bid)
+  - close-short via TWAP (side=Long, sz=0.25 per slice)
+  - 即時 abort
+  - total_duration timeout
+
+## 関連
+
+- [MARKET](market.md) — child として呼ばれる taker
+- [PASSIVE_FOLLOW](passive_follow.md) — child=passive の概念ベース
+- [MARKET_MAKE](market_make.md) — 両側 maker

--- a/docs/executor/api/rest.md
+++ b/docs/executor/api/rest.md
@@ -1,0 +1,281 @@
+# REST API リファレンス
+
+base URL: `http://127.0.0.1:8085` (デフォルト. `EXECUTOR_BIND` 環境変数で変更可)
+
+すべてのレスポンスは `Content-Type: application/json`。
+エラーレスポンスは:
+
+```json
+{ "code": "<not_found|bad_request|conflict|internal>", "message": "<説明>" }
+```
+
+`internal` の場合, クライアントに渡す message は固定文字列 (`"internal server error"`).
+詳細は server-side log のみに記録される (Gemini PR-7 セキュリティ指摘反映).
+
+---
+
+## エンドポイント一覧
+
+| Method | Path | 用途 |
+|---|---|---|
+| GET | `/v1/health` | ヘルスチェック + アルゴリズム一覧 |
+| GET | `/v1/positions` | 全シンボルの現在ポジション |
+| GET | `/v1/book/{symbol}` | top-of-book スナップショット |
+| POST | `/v1/exec` | execution 起動 |
+| GET | `/v1/exec/{id}` | execution 状態 + 終了レポート |
+| POST | `/v1/exec/{id}/cancel` | 個別 abort |
+| POST | `/v1/emergency_stop` | キルスイッチ (全 cancel + 全 abort) |
+| GET | `/v1/exec/{id}/ws` | WebSocket Progress ストリーム ([websocket.md](websocket.md)) |
+
+---
+
+## `GET /v1/health`
+
+サーバが受付可能か, どのアルゴリズムをサポートしているか確認。
+
+```bash
+curl http://127.0.0.1:8085/v1/health
+```
+
+```json
+{
+  "status": "ok",
+  "algorithms": ["market", "passive", "twap", "market_make"],
+  "health": {
+    "ws_connected": false,
+    "last_book_update": null,
+    "last_user_event": null,
+    "last_reconciliation": null,
+    "ws_reconnect_count": 0,
+    "ws_message_count": 0
+  },
+  "running_executions": 0
+}
+```
+
+| フィールド | 型 | 説明 |
+|---|---|---|
+| `status` | string | 常に `"ok"` (このフィールドの存在自体が起動完了を表す) |
+| `algorithms` | string[] | OrderRouter が build できる名前 (snake_case) |
+| `health` | object | WS 接続状態, 直近イベント時刻, reconnect 回数 |
+| `running_executions` | u64 | ExecutionRegistry が保持する全 entry 数 (終了済み含む) |
+
+---
+
+## `GET /v1/positions`
+
+全シンボルの現在ポジションを返す。
+
+```bash
+curl http://127.0.0.1:8085/v1/positions
+```
+
+```json
+{
+  "positions": {
+    "BTC": {
+      "size": "0.5",
+      "entry_px": "49500.0",
+      "unrealized_pnl": "100.0",
+      "margin_used": "1000.0",
+      "last_update": "2026-05-04T07:23:11.123Z"
+    }
+  }
+}
+```
+
+`size` は **signed** (positive=long, negative=short). 精度保持のため string で送出。
+
+---
+
+## `GET /v1/book/{symbol}`
+
+top-of-book スナップショット。symbol は `BTC` / `xyz:SP500` 等そのまま。
+
+```bash
+curl http://127.0.0.1:8085/v1/book/BTC
+```
+
+```json
+{
+  "bids": [{"px": "49999", "sz": "10", "n": 1}],
+  "asks": [{"px": "50001", "sz": "10", "n": 1}],
+  "ts":   "2026-05-04T07:23:11.123Z"
+}
+```
+
+`ts` は WS 受信時刻。`null` の場合は WS 未接続/未配信。
+`AppState::book` に該当 symbol が無ければ **404 not_found**。
+
+---
+
+## `POST /v1/exec`
+
+execution を起動して `exec_id` を返す。
+
+### リクエスト
+
+```json
+{
+  "algorithm":   "market",
+  "symbol":      "BTC",
+  "intent":      "open",
+  "target_size": "0.1",
+  "params":      { "max_slippage_bps": "20" }
+}
+```
+
+| フィールド | 型 | 説明 |
+|---|---|---|
+| `algorithm` | string | `market` / `passive` / `twap` / `market_make` (大文字小文字無視, 別名 `passive_follow` / `mm` 可) |
+| `symbol` | string | `BTC` / `xyz:SP500` 等 |
+| `intent` | enum | `open` / `close` / `set_target` (詳細は[各 algo doc](../algorithms/) 参照) |
+| `target_size` | string→Decimal | f64 経由を避けるため文字列で送る。`"0.1"` 推奨 |
+| `params` | object | アルゴリズム別パラメータ (各 algo doc 参照) |
+
+### レスポンス (200 OK)
+
+```json
+{
+  "exec_id":   "0190bd51-f2cd-7e4f-9b3a-89f5...",
+  "algorithm": "MARKET"
+}
+```
+
+`exec_id` は uuid v7 (時刻順序保持)。
+
+### エラー
+
+| status | code | 条件 |
+|---|---|---|
+| 400 | `bad_request` | `algorithm` が未対応 / target_size が不正 / params が algo 仕様違反 |
+
+---
+
+## `GET /v1/exec/{id}`
+
+execution の状態と最終レポート。
+
+```bash
+curl http://127.0.0.1:8085/v1/exec/0190bd51-f2cd-7e4f-9b3a-89f5...
+```
+
+```json
+{
+  "exec_id":   "0190bd51-...",
+  "algorithm": "MARKET",
+  "status":    "completed",
+  "report": {
+    "exec_id":      "0190bd51-...",
+    "algorithm":    "MARKET",
+    "started_at":   "2026-05-04T07:23:11.000Z",
+    "finished_at":  "2026-05-04T07:23:12.345Z",
+    "target_size":  "0.1",
+    "filled_size":  "0.1",
+    "avg_px":       "50001.5",
+    "total_fees":   "0.012",
+    "fills": [
+      {"symbol":"BTC","cloid":"0x019...","oid":1234,"side":"long",
+       "px":"50001","sz":"0.05","fee":"0.006","ts":"..."},
+      {"symbol":"BTC","cloid":"0x019...","oid":1235,"side":"long",
+       "px":"50002","sz":"0.05","fee":"0.006","ts":"..."}
+    ],
+    "aborted": false,
+    "abort_reason": null
+  },
+  "error": null
+}
+```
+
+`status` の取りうる値:
+
+| status | 意味 |
+|---|---|
+| `running` | 実行中 |
+| `finalizing` | join handle が finished だが未だレポート抽出中 (Gemini PR-7 race 対策の中間 state) |
+| `completed` | 完了 (`report.aborted == false`) |
+| `aborted` | abort 経由で完了 (`report.aborted == true`) |
+| `failed` | algo が `Err` を返した / panic 等 |
+
+`finalizing` を見たクライアントは数十 ms 後に再度 GET すると確定状態が取れる。
+
+### エラー
+
+| status | code | 条件 |
+|---|---|---|
+| 400 | `bad_request` | `id` が UUID として parse 不可 |
+| 404 | `not_found` | 該当 exec_id がレジストリに存在しない |
+
+---
+
+## `POST /v1/exec/{id}/cancel`
+
+特定 execution を abort する。サーバは即座に 200 を返し, 実際の cancel 発信は次の BatchSender flush (≦100ms) で行われる。
+
+```bash
+curl -X POST http://127.0.0.1:8085/v1/exec/0190bd51-.../cancel
+```
+
+```json
+{ "exec_id": "0190bd51-...", "abort_signaled": true }
+```
+
+`abort_signaled` は **abort watch channel に true を send した** ことを示す。
+target_size に達した直後など, algo が abort より早く完了した場合でも `true` を返す (idempotent)。
+
+---
+
+## `POST /v1/emergency_stop`
+
+**キルスイッチ**: 全 execution を abort + 全 open order を一括 cancel。
+
+```bash
+curl -X POST -H "X-Operator-ID: alice@desk" \
+  http://127.0.0.1:8085/v1/emergency_stop
+```
+
+```json
+{
+  "aborted_executions": 3,
+  "cancelled_orders":   12
+}
+```
+
+### 仕様 (Gemini PR-8 review 反映)
+
+1. **Step 1: cancel 先行**  
+   `AppState::open_orders` を snapshot → 全件 `CancelIntent` を BatchSender に enqueue
+2. **Step 2: abort 後置**  
+   `ExecutionRegistry::abort_all()` で全 Running 状態の algo に abort 信号  
+   - 順序を逆にすると, abort 信号到達前に algo が新規 order を enqueue する余地が残る
+
+### `X-Operator-ID` ヘッダ
+
+監査ログ用の操作者識別子。任意。指定すると `tracing::warn!` ログに `operator=...` で残る。
+未指定時は `unknown` で記録。
+
+```text
+WARN executor_server::routes operator="alice@desk" aborted_executions=3 cancelled_orders=12 emergency_stop dispatched
+```
+
+実運用では Auth/SSO レイヤから取得した識別子をプロキシで設定する想定 (現状の executor 自体は認証なし)。
+
+---
+
+## エラーコード対応
+
+| HTTP | code | 例 |
+|---|---|---|
+| 400 | `bad_request` | unknown algorithm, invalid uuid, AlgoError::InvalidParams |
+| 404 | `not_found` | book / execution が存在しない |
+| 409 | `conflict` | 同 exec_id 重複起動 (現状未発生だが ExecutorError::ExecutionAlreadyRunning が予約) |
+| 500 | `internal` | unexpected. message は固定文字列で詳細は log のみ |
+
+---
+
+## 関連ドキュメント
+
+- [WebSocket リファレンス](websocket.md)
+- [Python connector](../connector/python.md)
+- [executor-cli](../cli.md)
+- [4 アルゴリズムの params](../algorithms/)

--- a/docs/executor/api/websocket.md
+++ b/docs/executor/api/websocket.md
@@ -1,0 +1,212 @@
+# WebSocket API リファレンス
+
+execution の Progress イベントをリアルタイムでストリームするための単一エンドポイント。
+
+```
+GET /v1/exec/{id}/ws
+Upgrade: websocket
+```
+
+各メッセージは **Text frame** (`Message::Text`) で, JSON シリアライズされた `Progress` enum。
+複数 subscriber が同じ exec_id を購読可能 (broadcast fan-out)。
+
+---
+
+## 接続
+
+### `wscat` で確認
+
+```bash
+# 起動済み executor-server に対して
+wscat -c "ws://127.0.0.1:8085/v1/exec/0190bd51-f2cd-7e4f-9b3a-.../ws"
+```
+
+### Python 連携
+
+```python
+from src.executor import ExecutorClient
+
+async with ExecutorClient("http://127.0.0.1:8085") as cli:
+    resp = await cli.start(algorithm="market", symbol="BTC", intent="open", target_size="0.1")
+    async for evt in cli.stream(resp.exec_id):
+        print(evt)
+```
+
+詳細は [`../connector/python.md`](../connector/python.md)。
+
+---
+
+## メッセージスキーマ (Progress)
+
+Rust 側の `executor_core::intent::Progress` enum を `serde(tag = "type", rename_all = "snake_case")` で
+シリアライズしたもの。`type` フィールドで discriminate する。
+
+### 1. `started` — execution 開始
+
+```json
+{
+  "type":    "started",
+  "exec_id": "0190bd51-...",
+  "ts":      "2026-05-04T07:23:11.000Z"
+}
+```
+
+algo の `run()` 冒頭で 1 回だけ送出。
+
+---
+
+### 2. `slice_filled` — 1 つの fill が届いた
+
+```json
+{
+  "type":              "slice_filled",
+  "slice":             1,
+  "cloid":             "0x019defde36677fa287de0871c9f231a5",
+  "px":                "50001",
+  "sz":                "0.05",
+  "cumulative_filled": "0.05"
+}
+```
+
+| フィールド | 意味 |
+|---|---|
+| `slice` | アルゴリズム内の slice index (TWAP は 1〜slice_count, MARKET は試行回数, PASSIVE / MM は 0 固定) |
+| `cloid` | この fill に紐づく cloid (`0x` + 32 hex) |
+| `px` | 約定価格 (string Decimal) |
+| `sz` | 約定サイズ (string Decimal) |
+| `cumulative_filled` | この event 終了時点の累積約定サイズ |
+
+---
+
+### 3. `heartbeat` — 進捗ハートビート
+
+```json
+{
+  "type":              "heartbeat",
+  "cumulative_filled": "0.05",
+  "remaining":         "0.05",
+  "ts":                "2026-05-04T07:23:11.500Z"
+}
+```
+
+長時間稼働の algo (TWAP, MARKET_MAKE) が slice 間/repost loop 間で送出。
+クライアントが切断検知に使える (一定時間届かなければ再接続)。
+
+---
+
+### 4. `aborted` — 途中停止
+
+```json
+{
+  "type":   "aborted",
+  "reason": "aborted by caller",
+  "ts":     "2026-05-04T07:23:12.000Z"
+}
+```
+
+> 注: 現実装では `aborted` Progress 自体は明示送出していない。
+> 終了は `Completed` (with `report.aborted=true`) で表現される。
+> `aborted` は将来送出が想定される予約 variant。
+
+---
+
+### 5. `completed` — 正常完了 / 完了
+
+```json
+{
+  "type":         "completed",
+  "filled_size":  "0.1",
+  "avg_px":       "50001.5",
+  "total_fees":   "0.012",
+  "n_fills":      2,
+  "ts":           "2026-05-04T07:23:12.345Z"
+}
+```
+
+algo の最後に必ず 1 回送出される。`avg_px` は `Σ(px*sz) / Σsz`。
+
+その後サーバは broadcast channel をクローズしないため (executor-server lifetime 中は維持),
+完了後に新規 subscriber が繋いだ場合は何も流れない (REST GET で final report を取得すべき)。
+
+---
+
+### 6. `error` — 異常
+
+```json
+{
+  "type":    "error",
+  "message": "...",
+  "ts":      "..."
+}
+```
+
+将来の拡張用。現実装では Algorithm が `Err` を返した場合 Progress には流さず,
+`/v1/exec/{id}` の `status=failed` + `error` フィールドで通知する。
+
+---
+
+## 切断条件
+
+サーバ側から close するタイミングは以下:
+
+| 条件 | 挙動 |
+|---|---|
+| クライアントが `Close` frame 送信 | 即座に close |
+| broadcast channel が `Lagged(n)` を返した | 警告ログを出して close (HFT で stale を流さない方針) |
+| broadcast channel が `Closed` (sender drop) | close |
+
+`Lagged` 時のクライアント実装ガイド:
+- 再接続して REST `/v1/exec/{id}` で現在の累積約定を取得
+- 過去イベントは再送されない (broadcast の性質)
+
+---
+
+## バックプレッシャ / バッファ容量
+
+`broadcast::channel(256)` で生成。長期 MM などで 256 件溜まると新規 event は古いものを上書き、
+slow consumer は `Lagged` で蹴られる。
+
+将来課題 (Gemini PR-7 指摘):
+- 高頻度 MM 用に容量を 1024 等に増やす検討
+- クライアント側の指数バックオフ再接続 (現状未実装. Python connector でも要追加)
+
+---
+
+## エラー
+
+`/v1/exec/{id}/ws` 自体のエラーは upgrade 前に HTTP として返る:
+
+| status | code | 条件 |
+|---|---|---|
+| 400 | `bad_request` | `id` が UUID として parse 不可 |
+| 404 | `not_found` | 該当 exec_id が無い |
+
+upgrade 後はエラー応答できないため, 上記のような異常が起きた場合は close で通知される。
+
+---
+
+## サンプル: 1 execution の完全な event 列
+
+MARKET algo で `target_size=0.1`, slice 1 で full fill した場合:
+
+```json
+{"type":"started","exec_id":"...","ts":"2026-05-04T07:23:11.000Z"}
+{"type":"slice_filled","slice":1,"cloid":"0x...","px":"50001","sz":"0.1","cumulative_filled":"0.1"}
+{"type":"completed","filled_size":"0.1","avg_px":"50001","total_fees":"0.012","n_fills":1,"ts":"..."}
+```
+
+PASSIVE_FOLLOW で 2 回 partial fill した場合:
+
+```json
+{"type":"started",...}
+{"type":"slice_filled","slice":0,"cloid":"0x...A","px":"49999","sz":"0.06","cumulative_filled":"0.06"}
+{"type":"slice_filled","slice":0,"cloid":"0x...B","px":"50000","sz":"0.04","cumulative_filled":"0.10"}
+{"type":"completed","filled_size":"0.10","avg_px":"49999.6","total_fees":"...","n_fills":2,"ts":"..."}
+```
+
+---
+
+## 関連
+
+- [REST リファレンス](rest.md)
+- [Python connector](../connector/python.md) — `ExecutorClient.stream(exec_id)`

--- a/docs/executor/architecture.md
+++ b/docs/executor/architecture.md
@@ -1,0 +1,193 @@
+# アーキテクチャ概要
+
+> 詳細な設計理由 (cancel 戦略, nonce 管理, RwLock 分割理由など) は
+> [`../specs/2026-05-04-rust-executor-design.md`](../specs/2026-05-04-rust-executor-design.md) を参照。
+> 本ドキュメントは「実装後の現状」を整理した俯瞰資料。
+
+## Cargo workspace 構成 (5 crate)
+
+```
+executor/
+├── Cargo.toml                       # workspace root
+└── crates/
+    ├── executor-core/               # types/state/intent/cloid/nonce — IO なし
+    │   ├── cloid.rs                 # uuid v7 → 0x + 32 hex
+    │   ├── errors.rs                # AlgoError / ExecutorError
+    │   ├── intent.rs                # Intent / OrderIntent / Progress / ExecutionReport
+    │   ├── nonce.rs                 # NonceManager (atomic + 100 件 rolling window)
+    │   ├── state.rs                 # AppState (book/position/open_orders/fills/health 分割 lock)
+    │   ├── symbol.rs                # Symbol — HIP-3 dex 識別
+    │   └── types.rs                 # Address / Side / Tif / OrderId / Fill
+    │
+    ├── executor-hl/                 # HL 通信 + 鍵を扱う唯一の crate
+    │   ├── batch_sender.rs          # mpsc + 100ms flusher (order/cancel 分離)
+    │   ├── errors.rs                # HlError
+    │   ├── hl_client.rs             # HlClient trait + MockHlClient + RealHlClient (骨格)
+    │   ├── rate_limiter.rs          # TokenBucket (HL ~1200/min)
+    │   ├── signer.rs                # Signer trait + MockSigner (実 EIP-712 は別 PR)
+    │   └── ws_state.rs              # WsStateManager (split-lock 更新)
+    │
+    ├── executor-algo/               # Algorithm trait + 4 アルゴリズム + 共通 helpers
+    │   ├── algorithm.rs             # Algorithm trait, ExecutionContext, helpers
+    │   ├── market.rs                # MARKET (taker IOC + slippage cap)
+    │   ├── passive_follow.rs        # PASSIVE_FOLLOW (maker ALO at touch)
+    │   ├── twap.rs                  # TWAP (時間スライス)
+    │   └── market_make.rs           # MARKET_MAKE (target 駆動 2-sided ALO)
+    │
+    ├── executor-server/             # axum REST + WS
+    │   ├── lib.rs                   # build_app(state) → Router
+    │   ├── error.rs                 # ServerError + axum IntoResponse
+    │   ├── registry.rs              # ExecutionRegistry / ExecutionHandle
+    │   ├── router.rs                # OrderRouter — name → Box<dyn Algorithm>
+    │   ├── routes.rs                # REST handler 群
+    │   ├── state.rs                 # ServerState (Arc<AppState> + ...)
+    │   ├── ws.rs                    # /v1/exec/{id}/ws ハンドラ
+    │   ├── main.rs                  # bin: 起動 + tracing 設定
+    │   └── tests/integration_rest.rs  # tower::ServiceExt::oneshot e2e
+    │
+    └── executor-cli/                # 開発用 CLI (clap)
+        └── main.rs                  # 7 サブコマンド (health/.../emergency-stop)
+```
+
+### crate 依存関係
+
+```
+executor-server ──▶ executor-algo ──▶ executor-hl ──▶ executor-core
+                            │                  │
+                            └────── executor-core ◄─┘
+
+executor-cli ──▶ executor-core (型のみ依存)
+```
+
+`executor-hl` のみが HL ネットワーク + 鍵を触る。アルゴリズムは `BatchSender` 経由でしか発注できないため、
+レート制御 / 100ms バッチ / cloid トラッキング が一律に強制される。
+
+## データフロー: 1 回の execution が走るとき
+
+```
+[Python 戦略]
+    │ HTTP POST /v1/exec
+    │ {"algorithm":"twap","symbol":"BTC","intent":"open","target_size":"0.1",
+    │  "params":{"slice_count":10,"total_duration_ms":60000}}
+    ▼
+[axum routes::start_exec]
+    │ 1) validate_algorithm_name()
+    │ 2) OrderRouter::build("twap") → Box<dyn Algorithm>
+    │ 3) ExecutionId::new() (uuid v7)
+    │ 4) watch::channel(false)        ─ abort 用
+    │ 5) broadcast::channel<Progress>  ─ WS subscriber 用
+    │ 6) mpsc::channel<Progress>       ─ algo → bridge task
+    │ 7) ExecutionContext を組み立て tokio::spawn(algo.run(ctx))
+    │ 8) ExecutionHandle 作成 → ExecutionRegistry に登録
+    ▼
+[TwapAlgorithm::run]  (async, 別タスク)
+    │ for slice_idx in 1..=slice_count:
+    │   * AppState.book を read_lock で snapshot
+    │   * ensure_book_fresh()
+    │   * resolve_side_and_size()
+    │   * cloid 生成 → BatchSender::enqueue(Place(OrderIntent))
+    │   * drain_new_fills() で Progress::SliceFilled 発行
+    │   * tokio::time::sleep(interval)
+    │ build_report(...) → return
+    ▼
+[executor-hl::batch_sender flusher]
+    │ 100ms 毎に order_intents / cancel_intents を分離して
+    │ HlClient::place_orders() / .cancel_orders() を呼ぶ
+    ▼
+[MockHlClient]
+    │ 80% プロト: orders を Vec に記録, oid 模擬値返す
+    │ Real (将来): EIP-712 署名 + POST /exchange
+    ▼
+[HL exchange]  (将来)
+```
+
+並行して:
+
+```
+[axum ws::progress_ws]
+    │ /v1/exec/{id}/ws upgrade
+    │ ExecutionHandle.progress.subscribe()
+    │ broadcast::Receiver で algo の Progress を Text frame として転送
+    │ Lagged → close (HFT 文脈で stale データを送らない)
+```
+
+```
+[axum routes::cancel_exec]
+    │ POST /v1/exec/{id}/cancel
+    │ ExecutionHandle.abort.send(true)
+    ▼
+[Algorithm::run の loop]
+    │ if *abort_rx.borrow() { 板上 order を CancelIntent で BatchSender 経由 cancel; return aborted=true }
+```
+
+## AppState の split-lock 戦略
+
+単一 `RwLock` だと高頻度な book 更新 (write) が algo の read を starve させるため、
+4 種類の lock を独立保持:
+
+```rust
+pub struct AppState {
+    pub book:         Arc<RwLock<HashMap<Symbol, OrderBook>>>,
+    pub position:     Arc<RwLock<HashMap<Symbol, Position>>>,
+    pub open_orders:  Arc<RwLock<HashMap<Cloid, OpenOrder>>>,
+    pub recent_fills: Arc<RwLock<VecDeque<Fill>>>,
+    pub health:       Arc<RwLock<HealthStatus>>,
+    pub nonce_mgr:    Arc<NonceManager>,
+}
+```
+
+**append-only 不変条件**: `recent_fills` は `push_back` のみで成長する。
+`drain_new_fills(.., last_seen_idx)` の usize index ロジックは
+この append-only 性に依存する (`docs/executor/algorithms/*.md` 参照)。
+
+## ExecutionRegistry: 実行中ジョブの管理
+
+```rust
+pub struct ExecutionRegistry {
+    inner: RwLock<HashMap<ExecutionId, Arc<RwLock<ExecutionHandle>>>>,
+}
+
+pub struct ExecutionHandle {
+    pub exec_id: ExecutionId,
+    pub algorithm: String,
+    pub abort: watch::Sender<bool>,           // /cancel + emergency_stop で true
+    pub progress: broadcast::Sender<Progress>, // WS subscriber 用
+    pub join: Option<JoinHandle<...>>,        // GET /v1/exec/{id} で finalize
+    pub status: ExecutionStatus,              // Running/Finalizing/Completed/Aborted/Failed
+    pub final_report: Option<ExecutionReport>,
+    pub final_error: Option<String>,
+}
+```
+
+`ExecutionStatus::Finalizing` は **GET /v1/exec/{id} の race 対策中間 state**。
+join.take() → handle.await の隙に他 GET が入っても "ほぼ完了" を表現可。
+
+## Cancel 戦略 (重要)
+
+**HL の nonce 無効化は in-flight (未到達) request を弾くだけ. 板上の指値は cancel されない。**
+従って:
+
+1. 各 order に **cloid (16 byte client-generated)** を付与
+2. cancel は `BatchSender::enqueue(OrderOrCancel::Cancel(CancelIntent { by_cloid: Some(c), .. }))`
+3. `POST /v1/emergency_stop` は **Cancel-then-Abort** 順序:
+   - Step 1: `AppState::open_orders` を snapshot し, 全件 CancelIntent を batch enqueue
+   - Step 2: `ExecutionRegistry::abort_all()` で全 algo に abort 信号
+   - 順序逆だと, abort 信号到達前に algo が新規 order を enqueue する余地がある (Gemini PR-8 指摘)
+
+## Rate limit + Batch flush
+
+- TokenBucket: HL ガイダンス ~1200 req/min - margin → 安全側で運用
+- BatchSender: mpsc → 100ms tick で order/cancel を分離して `place_orders` / `cancel_orders` 一括送信
+- `place_orders` と `cancel_orders` を別 batch にする理由: HL は ALO と IOC/GTC を別 batch 推奨
+
+## Time handling: `tokio::time::Instant`
+
+長時間 loop (PASSIVE_FOLLOW, TWAP, MARKET_MAKE) の deadline 計測は **必ず `tokio::time::Instant`** を使う。
+`std::time::Instant` だと `tokio::time::pause()` 環境 (paused-time テスト) で
+deadline が永遠に経過しない (PR-3 で Gemini 指摘)。
+
+## 参照
+
+- 設計仕様 v2: [`../specs/2026-05-04-rust-executor-design.md`](../specs/2026-05-04-rust-executor-design.md)
+- 各 algo 実装ノート: [`algorithms/`](algorithms/)
+- API 仕様: [`api/`](api/)

--- a/docs/executor/cli.md
+++ b/docs/executor/cli.md
@@ -1,0 +1,162 @@
+# `executor-cli`
+
+Rust 製の REST クライアント。動作確認 / dry-run / 緊急停止に使う。
+
+> 実装: [`executor/crates/executor-cli/src/main.rs`](../../executor/crates/executor-cli/src/main.rs)
+> PR: [#65](https://github.com/howlrs/diff-old-new/pull/65)
+
+## ビルド & 設置
+
+```bash
+cd executor
+cargo build -p executor-cli --release
+ls target/release/executor-cli   # → 実行可能ファイル
+
+# (option) PATH に通す
+ln -s "$(pwd)/target/release/executor-cli" ~/bin/executor-cli
+```
+
+cargo run でも可:
+
+```bash
+cargo run -p executor-cli -- <subcommand>
+```
+
+## グローバルオプション
+
+| フラグ | 環境変数 | デフォルト | 説明 |
+|---|---|---|---|
+| `--url <URL>` | `EXECUTOR_URL` | `http://127.0.0.1:8085` | サーバ URL (末尾スラッシュなし) |
+
+## サブコマンド
+
+### `health`
+
+```bash
+executor-cli health
+```
+
+```json
+{
+  "status": "ok",
+  "algorithms": ["market", "passive", "twap", "market_make"],
+  "health": { ... },
+  "running_executions": 0
+}
+```
+
+### `positions`
+
+```bash
+executor-cli positions
+```
+
+### `book <symbol>`
+
+```bash
+executor-cli book BTC
+```
+
+### `exec`
+
+```bash
+executor-cli exec \
+  --algo market \
+  --symbol BTC \
+  --intent open \
+  --size 0.1 \
+  --params '{"max_slippage_bps":"20","max_attempts":3}'
+```
+
+| フラグ | 必須 | 内容 |
+|---|---|---|
+| `--algo` | ✓ | `market` / `passive` / `twap` / `market_make` |
+| `--symbol` | ✓ | symbol 名 |
+| `--intent` | デフォルト `open` | `open` / `close` / `set_target` |
+| `--size` | ✓ | string Decimal で送信 |
+| `--params` | デフォルト `{}` | JSON object 文字列 |
+
+JSON が malformed なら **process が即時 exit**。シェル引数の quote に注意。
+
+```json
+{ "exec_id": "0190bd51-f2cd-7e4f-...", "algorithm": "MARKET" }
+```
+
+### `status <id>`
+
+```bash
+executor-cli status 0190bd51-f2cd-7e4f-...
+```
+
+### `cancel <id>`
+
+```bash
+executor-cli cancel 0190bd51-f2cd-7e4f-...
+```
+
+### `emergency-stop`
+
+```bash
+executor-cli emergency-stop
+```
+
+> 注: `executor-cli` は現状 `X-Operator-ID` を送らない。
+> auditability が必要な現場では `curl -H "X-Operator-ID: ..."` か Python connector ラッパを使う。
+
+## ログ出力
+
+`RUST_LOG=info executor-cli ...` で trace/debug を出せる。デフォルトは `warn`。
+
+```bash
+RUST_LOG=executor_cli=debug,reqwest=info executor-cli health
+```
+
+## エラー
+
+サーバが 4xx/5xx を返すと `Error: HTTP <code>: <body>` で exit code 1。
+
+```bash
+$ executor-cli book BTC
+Error: HTTP 404 Not Found: {"code":"not_found","message":"book for BTC"}
+```
+
+サーバ自体に到達できない (port 違い / 未起動) と reqwest 側のエラーが出る:
+
+```bash
+$ executor-cli health --url http://127.0.0.1:9999
+Error: error sending request for url (http://127.0.0.1:9999/v1/health): error trying to connect: ...
+```
+
+## ユースケース
+
+### A. 開発中の手早い動作確認
+
+```bash
+# 別 terminal で
+EXECUTOR_BIND=127.0.0.1:8085 cargo run -p executor-server --release
+
+# 確認
+executor-cli health
+executor-cli exec --algo market --symbol BTC --intent open --size 0.01
+executor-cli status <exec_id>
+```
+
+### B. キルスイッチ (運用)
+
+```bash
+EXECUTOR_URL=https://exec.internal:8443 executor-cli emergency-stop
+```
+
+(本番では mTLS / Auth proxy を前段に入れる前提. 後述の operations/deployment.md 参照)
+
+### C. CI から spawn して smoke
+
+[`tests/test_executor_client_live.py`](../../tests/test_executor_client_live.py) と同様,
+shell から `executor-server` を spawn → `executor-cli health` を polling して起動完了確認 →
+本テスト, という pattern が組める。
+
+## 関連
+
+- [REST API リファレンス](api/rest.md)
+- [Python connector](connector/python.md)
+- [運用ガイド](operations/deployment.md)

--- a/docs/executor/connector/python.md
+++ b/docs/executor/connector/python.md
@@ -1,0 +1,189 @@
+# Python connector (`src/executor/`)
+
+Python 戦略レイヤから Rust executor-server を叩くための async クライアント。
+
+> 実装: [`src/executor/client.py`](../../../src/executor/client.py)
+> PR: [#65](https://github.com/howlrs/diff-old-new/pull/65)
+
+## インストール
+
+`src/executor/__init__.py` は既に repo に含まれており, `pip install -e ".[dev,all]"`
+で追加導入は不要。WebSocket ストリームを使う場合のみ `websockets~=16.0` が必要 (`pyproject` の base 依存に含まれている)。
+
+## API 概要
+
+```python
+from src.executor import (
+    Algorithm,           # StrEnum: MARKET / PASSIVE / TWAP / MARKET_MAKE
+    Intent,              # StrEnum: OPEN / CLOSE / SET_TARGET
+    ExecutionStatus,     # StrEnum: RUNNING / FINALIZING / COMPLETED / ABORTED / FAILED
+    ExecutorClient,      # async client
+    ExecutorClientError, # raised on non-2xx
+)
+```
+
+`ExecutorClient` は **async context manager** として使う必要がある:
+
+```python
+async with ExecutorClient("http://127.0.0.1:8085", timeout=10.0) as cli:
+    health = await cli.health()
+```
+
+context manager 外で呼ぶと `RuntimeError`。
+
+## メソッド
+
+| メソッド | REST 対応 | 戻り値 |
+|---|---|---|
+| `await cli.health()` | GET /v1/health | `dict` |
+| `await cli.positions()` | GET /v1/positions | `dict` |
+| `await cli.book(symbol)` | GET /v1/book/{symbol} | `dict` |
+| `await cli.start(...)` | POST /v1/exec | `StartResponse(exec_id, algorithm)` |
+| `await cli.status(id)` | GET /v1/exec/{id} | `dict` |
+| `await cli.cancel(id)` | POST /v1/exec/{id}/cancel | `dict` |
+| `await cli.emergency_stop()` | POST /v1/emergency_stop | `dict` |
+| `cli.stream(id)` | GET /v1/exec/{id}/ws | `AsyncIterator[dict]` |
+
+## サンプル
+
+### A. MARKET で 0.1 BTC を取って完了まで待つ
+
+```python
+import asyncio
+from src.executor import ExecutorClient, Algorithm, Intent, ExecutionStatus
+
+async def main():
+    async with ExecutorClient("http://127.0.0.1:8085") as cli:
+        resp = await cli.start(
+            algorithm=Algorithm.MARKET,
+            symbol="BTC",
+            intent=Intent.OPEN,
+            target_size="0.1",
+            params={"max_slippage_bps": "20", "max_attempts": 3},
+        )
+        print(f"started exec_id={resp.exec_id}")
+
+        # ポーリングで完了待ち
+        while True:
+            st = await cli.status(resp.exec_id)
+            if st["status"] in (
+                ExecutionStatus.COMPLETED,
+                ExecutionStatus.ABORTED,
+                ExecutionStatus.FAILED,
+            ):
+                print(f"final status: {st['status']}")
+                print(st["report"])
+                break
+            await asyncio.sleep(0.2)
+
+asyncio.run(main())
+```
+
+### B. WS で Progress を受けながら実行
+
+```python
+async def stream_example():
+    async with ExecutorClient("http://127.0.0.1:8085") as cli:
+        resp = await cli.start(
+            algorithm=Algorithm.TWAP,
+            symbol="BTC",
+            intent=Intent.OPEN,
+            target_size="1.0",
+            params={"slice_count": 10, "total_duration_ms": 60000},
+        )
+        async for evt in cli.stream(resp.exec_id):
+            t = evt.get("type")
+            if t == "started":
+                print("▶ started")
+            elif t == "slice_filled":
+                print(f"  slice {evt['slice']}: +{evt['sz']} @ {evt['px']} (cum={evt['cumulative_filled']})")
+            elif t == "heartbeat":
+                print(f"  hb: filled={evt['cumulative_filled']} remaining={evt['remaining']}")
+            elif t == "completed":
+                print(f"✓ completed avg_px={evt['avg_px']} fills={evt['n_fills']}")
+                break
+```
+
+### C. キルスイッチ (operator id 付き)
+
+```python
+async def kill_all():
+    async with ExecutorClient("http://127.0.0.1:8085") as cli:
+        body = await cli.emergency_stop()
+        print(f"aborted={body['aborted_executions']} cancelled={body['cancelled_orders']}")
+```
+
+> **注**: 現状の Python connector は `X-Operator-ID` をパラメータとして受け付けていない。
+> 必要な場合は client を継承してヘッダ追加するか, httpx Client 直接利用が必要 (将来課題)。
+
+## エラーハンドリング
+
+```python
+from src.executor import ExecutorClientError
+
+async with ExecutorClient(url) as cli:
+    try:
+        await cli.start(algorithm="vwap", symbol="BTC", intent="open", target_size="0.1")
+    except ExecutorClientError as e:
+        if e.status == 400:
+            print(f"bad request: {e.body}")  # {"code":"bad_request","message":"unknown algorithm: 'vwap'"}
+        elif e.status == 404:
+            print(f"not found: {e.body}")
+        else:
+            raise
+```
+
+`ExecutorClientError(status, body)` の `body` は dict (parse 成功時) or str。
+
+## 型ヒント
+
+すべて `from __future__ import annotations` 前提で `typing` 型ヒント完備。
+`mypy src/executor` でチェック済み (CI で自動実行)。
+
+`Decimal` を渡したい場合:
+
+```python
+from decimal import Decimal
+await cli.start(..., target_size=Decimal("0.123456789012345"))  # str(...) でシリアライズされる
+```
+
+## StrEnum vs str
+
+`Algorithm.MARKET` は `StrEnum` なので `"market"` と等価:
+
+```python
+Algorithm.MARKET == "market"  # True
+Algorithm.MARKET.value         # "market"
+```
+
+文字列直書きでも OK:
+
+```python
+await cli.start(algorithm="passive_follow", ...)  # 別名も Rust 側で受け付ける
+await cli.start(algorithm=Algorithm.PASSIVE, ...) # 推奨
+```
+
+## live e2e テスト
+
+実バイナリを起動してエンドツーエンドで叩くテストが [`tests/test_executor_client_live.py`](../../../tests/test_executor_client_live.py) にあり,
+`pytest -m live` で実行可。CI ではデフォルト skip。
+
+```bash
+cd executor && cargo build -p executor-server
+cd .. && pytest tests/test_executor_client_live.py -m live -v
+```
+
+5 ケース: health, unknown algorithm 400, emergency_stop with no running, book 404,
+start MARKET → cancel/poll status の chain。
+
+## 制約 (Gemini PR-8 review より将来課題)
+
+- **schema 中央化**: 現状 StrEnum を手書きで Rust serde に揃えている。将来は Pydantic
+  + alias_generator で自動同期する案あり (今は採用せず, シンプル維持)
+- **WS 再接続**: 現状再接続 / Lagged バックオフは実装なし。Python 側で wrap が必要
+
+## 関連
+
+- [REST API](../api/rest.md)
+- [WebSocket API](../api/websocket.md)
+- [executor-cli](../cli.md)

--- a/docs/executor/operations/deployment.md
+++ b/docs/executor/operations/deployment.md
@@ -1,0 +1,126 @@
+# デプロイ・本番投入チェックリスト
+
+> **このドキュメントは「80 % プロトタイプから本番に進む前の段取り」を整理したもの**。
+> 現状の executor は keyless で動く Mock 構成のみ. 本番投入は **Phase 3.5 以降**。
+> 詳細な未完項目は [`../status.md`](../status.md) も参照。
+
+## 本番投入前に必ず行うこと
+
+### 1. 鍵管理ブレスト + 実装
+
+現状: `MockSigner` が `Signer` trait の唯一の impl。
+
+必要な作業:
+- [ ] HL agent wallet の運用フロー設計 (master EOA / agent wallet 関係, deregister 手順)
+- [ ] EIP-712 typed-data 構造の確定 (HL `/exchange` の正規化)
+- [ ] `Eip712AgentSigner` 実装 (`secrecy::Secret<...>` で秘密鍵を保持, `zeroize` で drop 時クリア)
+- [ ] 鍵注入経路 (env / vault / KMS) を決めて load 関数を追加
+- [ ] 失敗時の `HlError::Signature(...)` 経路を test
+- [ ] **agent wallet を 1 アルゴリズム = 1 wallet で割り当てる方針を確定**
+
+### 2. RealHlClient の `place_orders` / `cancel_orders` 完成
+
+現状: skeleton のみ. signer + rate_limiter は通すが POST `/exchange` 本体は `Err(HlError::Exchange { message: "not_implemented" })` を返す。
+
+必要な作業:
+- [ ] HL `/exchange` の payload schema を確定 (action, signature, nonce, vaultAddress)
+- [ ] レスポンス JSON のパース (oid 抽出, error code mapping)
+- [ ] 部分約定や resting 順位等の reconcilation 経路 (WS 経由 vs REST polling)
+
+### 3. Real WS subscriber の実装
+
+現状: `WsStateManager` は state 変換ロジックのみ. ネットワーク接続は別 PR。
+
+必要な作業:
+- [ ] `tokio-tungstenite` で `wss://api.hyperliquid.xyz/ws` 接続
+- [ ] 切断検知 + 指数バックオフ再接続
+- [ ] 起動時 + 再接続後 + 5 分ごとに `clearinghouseState` で reconcile
+- [ ] `clearinghouseState` JSON の完全パース (現状は最小限)
+
+### 4. 認証レイヤ (Auth)
+
+**Auth は executor-server 自身には組み込まない方針**。前段 reverse proxy で:
+
+- [ ] mTLS or SSO/JWT を強制
+- [ ] `X-Operator-ID` をプロキシで付与 (executor-server は信頼し log に残す)
+- [ ] rate limit を proxy 側でも入れる
+- [ ] CORS 等は proxy で
+- [ ] **public へ executor-server を晒さない** (8085 を VPS で外向きに開けない)
+
+### 5. オブザーバビリティ
+
+現状: `tracing` でログのみ。
+
+将来:
+- [ ] `tracing-subscriber` の JSON formatter で構造化ログ → Loki/Grafana
+- [ ] Prometheus exporter (P50/P99 レイテンシ, batch flush 数, fill 数等)
+- [ ] alert: `emergency_stop` 実行時 → Slack/PagerDuty
+
+### 6. サーバ構成
+
+| 項目 | 推奨 | 理由 |
+|---|---|---|
+| HL ノード距離 | HL validator にネットワーク的に近い VPS (us-east など) | 70ms HyperBFT finality 活用 |
+| systemd unit | restart=on-failure, journald 接続 | 単一プロセスで運用 |
+| プロセス数 | **agent wallet 数 × algorithm 種別** ぶん起動可 | nonce 競合回避 (per-process atomic counter) |
+| TLS | reverse proxy で終端 | executor 自身は HTTP のみ |
+
+## 設計上の制約 (運用前提)
+
+### 制約 1: BatchSender の 100 ms フラッシュ
+
+HL は ≤1 POST /100 ms ガイダンス。BatchSender の `flush_interval` は `BatchSenderConfig::default()` で 100 ms。
+変更すると HL が拒否しはじめる可能性 → 触らない。
+
+### 制約 2: cloid 一意性
+
+cloid は uuid v7 (時刻 + random). 1 プロセス内では衝突しない。
+複数プロセスでも v7 (random 部分) で実用上衝突しない想定。
+
+### 制約 3: `all_fills` 拡張 (MARKET_MAKE)
+
+長時間 MM では `all_fills: Vec<Fill>` が memory を食う。
+
+運用ルール:
+- ~1 時間ごとに execution をローテーション (cancel → 新 exec_id で再起動)
+- もしくは disk persist する wrapper を独自に書く
+
+### 制約 4: ExecutionRegistry の TTL なし
+
+完了済み execution も `Arc<RwLock<ExecutionHandle>>` で残り続ける。
+24h 連続稼働時は数千件溜まる可能性。
+
+将来作業:
+- [ ] `prune_completed(older_than)` を `ExecutionRegistry` に追加
+- [ ] 起動時に `--registry-ttl` などで設定可能化
+
+## 投入手順 (Phase 3.5 着手時の予定)
+
+```mermaid
+phase 3.5
+  ├── (1) 鍵管理ブレスト
+  ├── (2) Eip712AgentSigner + secrecy/zeroize
+  ├── (3) RealHlClient.place_orders / cancel_orders
+  ├── (4) Real WS subscriber + reconcilation
+  ├── (5) testnet で smoke (BTC で 0.001 BTC を MARKET / PASSIVE / TWAP / MM 1 round)
+  ├── (6) mTLS proxy + observability
+  └── (7) main net で micro-pos (0.01 BTC) で慎重に開始
+```
+
+## チェックリスト (本番投入直前)
+
+- [ ] 鍵管理: agent wallet が deregister 可能で master EOA と分離されている
+- [ ] `secrecy::Secret<...>` で秘密鍵が in-memory 平文で保持されない (gdb で確認)
+- [ ] `RealHlClient::place_orders` で **odd nonce** を使い切ったら graceful refresh される
+- [ ] testnet で MARKET / PASSIVE / TWAP / MM 各 1 ラウンドを成功
+- [ ] `POST /v1/emergency_stop` を testnet で実走 → 全 cancel が走ることを fill log で検証
+- [ ] mTLS proxy が `X-Operator-ID` を Auth 結果から自動付与している
+- [ ] ログが Loki / Grafana に流れている. emergency_stop の alert ルール設定
+- [ ] `ExecutionRegistry` の TTL/prune が CI 範囲で確認済 (将来)
+- [ ] CI が green ((cargo+pytest 共に))
+
+## 関連
+
+- [現状ステータス](../status.md)
+- [設計仕様 v2](../../specs/2026-05-04-rust-executor-design.md) §キー管理 / §テスト戦略
+- [troubleshooting](troubleshooting.md)

--- a/docs/executor/operations/dev-setup.md
+++ b/docs/executor/operations/dev-setup.md
@@ -1,0 +1,137 @@
+# 開発環境セットアップ
+
+## 前提
+
+| ツール | バージョン | 備考 |
+|---|---|---|
+| Rust | stable (1.85+) | `dtolnay/rust-toolchain@stable` で CI 同等 |
+| cargo | 同梱 | rustup で導入 |
+| Python | 3.12 系 | pyenv / asdf 推奨 |
+| Linux/WSL2 | 任意 | macOS でも動く想定だが CI は Ubuntu |
+
+## 初回セットアップ
+
+### 1. Rust workspace
+
+```bash
+cd executor
+cargo build --workspace
+```
+
+初回は依存解決で 200+ crate コンパイルされるため数分かかる。
+失敗するなら `cargo clean && cargo build --workspace` で.
+
+### 2. Python venv
+
+```bash
+cd /path/to/diff-old-new
+python -m venv .venv
+source .venv/bin/activate
+pip install -e ".[dev,all]"
+```
+
+`all` extra は GUI/audit 含む meta extra。 `dev` だけだと一部テストが skip される。
+
+## ビルドターゲット早見表
+
+| コマンド | やること |
+|---|---|
+| `cargo build` (executor 配下) | dev profile で全 crate ビルド |
+| `cargo build --release -p executor-server` | リリースバイナリのみ |
+| `cargo build -p executor-cli` | CLI のみ |
+| `cargo test --workspace --all-features` | 全 Rust test (CI と同じ) |
+| `cargo test -p executor-algo market_make::tests` | 単一モジュール |
+| `cargo fmt --all -- --check` | format 検証 (CI と同じ) |
+| `cargo clippy --workspace --all-targets -- -D warnings` | lint (CI と同じ) |
+
+## テスト分類
+
+### Rust
+
+| layer | crate | 件数 (2026-05-04) |
+|---|---|---|
+| core types | executor-core | 22 |
+| HL 基盤 | executor-hl | 17 |
+| algorithms | executor-algo | 56 |
+| server unit | executor-server | 8 |
+| server integration | executor-server (`tests/`) | 10 |
+| **計** | | **113** |
+
+### Python
+
+| layer | path | 件数 |
+|---|---|---|
+| 既存 (audit/strategy/etc) | `tests/test_*` | 71 |
+| executor connector unit | `tests/test_executor_client.py` | 8 |
+| executor connector live e2e | `tests/test_executor_client_live.py` | 5 (marker `live`) |
+
+CI はデフォルト `pytest -m "not live and not slow"` → 79 件実行。
+
+## ローカル CI 再現
+
+`scripts/check_ci_local.sh` が両方走らせる:
+
+```bash
+bash scripts/check_ci_local.sh
+```
+
+中身:
+1. Python: `ruff check` / `ruff format --check` / `mypy` / `pytest -m "not live and not slow"`
+2. Rust: `cargo fmt --check` / `cargo clippy -D warnings` / `cargo test --workspace`
+
+CI 失敗を防ぎたい場合は push 前に必ず実行 (CONTRIBUTING.md にも記載)。
+
+## サーバを起動して触る
+
+```bash
+cd executor
+cargo run -p executor-server --release
+
+# 別 terminal
+curl http://127.0.0.1:8085/v1/health | jq
+```
+
+`MockHlClient` + `MockSigner` なので keyless で動く。
+板情報は WS 未接続なので空。`POST /v1/exec` で MARKET algo を kick すると
+`market: empty asks` エラーで slice が失敗する → これが期待挙動。
+
+書き込みたい場合は **テスト用 fixture** を参照。`tests/integration_rest.rs` の
+`build_state_with_seed()` が AppState に手動で book / position をシードしている。
+
+## live e2e を回す
+
+```bash
+cd executor && cargo build -p executor-server   # debug build で OK
+cd ..
+source .venv/bin/activate
+pytest tests/test_executor_client_live.py -m live -v
+```
+
+5 ケース 1 秒未満で完了。fixture が free port を取り subprocess.Popen → /v1/health poll → tear down。
+
+## ディレクトリ早見表
+
+```
+diff-old-new/
+├── executor/                           # Rust workspace (8 PR で実装済)
+│   ├── Cargo.toml
+│   └── crates/{executor-core, executor-hl, executor-algo, executor-server, executor-cli}/
+├── src/
+│   ├── executor/                       # Python connector (PR-8)
+│   ├── audit/, l1_collector/, l2_features/, l3_strategy/, gui/, ...
+│   └── ...
+├── tests/                              # pytest
+│   ├── test_executor_client.py         # connector unit (CI 対象)
+│   ├── test_executor_client_live.py    # e2e live (marker live)
+│   └── test_*.py (audit/strategy/etc)
+├── docs/
+│   ├── executor/                       # ★ このディレクトリ
+│   ├── specs/2026-05-04-rust-executor-design.md
+│   ├── audit/, kpi/, ...
+│   └── phase-1-report.md
+└── scripts/check_ci_local.sh
+```
+
+## トラブルシューティング
+
+[`troubleshooting.md`](troubleshooting.md) を参照。

--- a/docs/executor/operations/troubleshooting.md
+++ b/docs/executor/operations/troubleshooting.md
@@ -1,0 +1,166 @@
+# Troubleshooting
+
+開発・運用中によく遭遇するエラーと対処。
+
+## ビルド系
+
+### 1. `cargo build` で `could not find Cargo.toml`
+
+```text
+error: could not find `Cargo.toml` in `/home/.../diff-old-new` or any parent directory
+```
+
+**原因**: workspace ルートは `executor/` 配下。  
+**対処**: `cd executor && cargo build`。 `executor/` の中で操作する。
+
+### 2. `cargo clippy -D warnings` が `unused_mut` で落ちる
+
+dev で書いたコードを `cargo clippy` に通したら lint で蹴られる。  
+**対処**: 警告メッセージに従い `mut` 削除 / 不要 import 削除。CI は `-D warnings` 強制なので
+ローカルで一度通しておく:
+
+```bash
+cd executor
+cargo clippy --workspace --all-targets -- -D warnings
+```
+
+### 3. `expect_used` clippy エラー
+
+`#![forbid(unsafe_code)]` + workspace lints で `unwrap_used` / `expect_used` が `warn`。
+production コードで使うと CI で fail.
+
+**対処**:
+- production: `Result<_, _>` で適切にエラーを伝播
+- test 内: モジュール冒頭に `#![allow(clippy::unwrap_used, clippy::expect_used)]` を入れる
+
+## サーバ起動系
+
+### 4. `executor-server` が即終了する
+
+```text
+Error: Address already in use (os error 98)
+```
+
+**原因**: port 8085 が他プロセス使用中。  
+**対処**: `EXECUTOR_BIND=127.0.0.1:9999 cargo run -p executor-server` で port 変更, または `lsof -i :8085` で衝突プロセス特定。
+
+### 5. systemd で起動するが動作しない
+
+journalctl で `tracing` ログを確認:
+
+```bash
+journalctl -u executor-server -f
+```
+
+最初に `executor-server listening` が出ればOK。出ていない場合は前段のセットアップで panic している (signer 初期化失敗等)。
+
+## アルゴリズム実行系
+
+### 6. `market: empty asks (no best ask)` が頻発する
+
+**原因**: `AppState.book` に該当 symbol のデータが無い。WS subscriber が未実装 (80% プロト) なため,
+本番では Real WS が必要。テストでは `tests/integration_rest.rs:build_state_with_seed()` のように手動シード。
+
+**対処 (開発時)**: テスト時は AppState に手動で seed する。または algo 起動前に
+`HlClient::fetch_book_snapshot()` を呼んで AppState に書き込む helper を追加。
+
+### 7. `book stale (XXXms > YYYms)` が頻発する
+
+**原因**:
+- WS が切断されている (本番では Real WS subscriber が再接続するまで)
+- 開発時 `tokio::time::pause()` 環境で Utc::now() のみ進んでいる
+
+**対処**:
+- 本番: WS 再接続を待つ. または `max_book_age_ms` を緩める (デフォルト 500ms)
+- テスト: `max_book_age_ms: 0` で freshness check を無効化
+
+### 8. MARKET algo が `max_attempts (5) exceeded with X.XX remaining` で aborted
+
+**原因**: IOC 投入後 `slice_timeout_ms` 内に fill が来ない. 板薄 / slippage 不足。
+
+**対処**:
+- `max_slippage_bps` を増やす
+- `slice_timeout_ms` を増やす
+- `max_attempts` を増やす
+- それでも fill されないなら板情報が古い疑い
+
+### 9. PASSIVE_FOLLOW が `max_total elapsed with N remaining` になる
+
+**原因**: maker order に touch しなかった. または板移動が頻繁すぎてキャンセルが間に合わない。
+
+**対処**:
+- `max_total_ms` を伸ばす
+- `child_algo: market` の TWAP に切り替える (確実に約定したい場合)
+- `repost_poll_ms` を短くする (ただしレート制限注意)
+
+### 10. MARKET_MAKE で `repost_bps_threshold = 0` 警告
+
+```text
+WARN executor_algo::market_make repost_bps_threshold = 0 triggers reposting on every mid change ...
+```
+
+**原因**: 設定値が小さすぎる。  
+**対処**: 本番では `≥1` (1bps) を推奨。0 は test 用。
+
+## Python connector
+
+### 11. `RuntimeError: ExecutorClient must be used as an async context manager`
+
+**原因**: `cli = ExecutorClient(url); await cli.health()` のように context manager 外で呼んだ。  
+**対処**: `async with ExecutorClient(url) as cli:` で囲む。
+
+### 12. `cli.stream(id)` で `RuntimeError: requires 'websockets'`
+
+**原因**: `websockets` package が import できない。  
+**対処**: `pip install -e ".[dev,all]"` で base 依存に含まれているはず。venv 確認。
+
+### 13. `ExecutorClientError(404, ...)` で `not_found`
+
+**原因**: exec_id が存在しない / book 未シード。  
+**対処**: 直前の `start()` の戻り値の `exec_id` を確認。typo していないか。
+
+## live e2e テスト
+
+### 14. `executor-server binary not found` で skip される
+
+```text
+SKIPPED [1] executor-server binary not found — run `cargo build -p executor-server` first
+```
+
+**原因**: バイナリ未ビルド。  
+**対処**: `cd executor && cargo build -p executor-server`。release でも debug でも fixture が拾う。
+
+### 15. `executor-server did not start in time`
+
+**原因**: 起動が 10 秒以内に /v1/health に応答しない。
+- TLS 周りのライブラリ build が走った直後だと起こる場合あり
+- マシン負荷高い
+
+**対処**:
+- 一度 `cargo run -p executor-server` を手で叩いて起動を見る
+- fixture の deadline を引き上げる (`tests/test_executor_client_live.py:69`)
+
+## CI
+
+### 16. CI の Python 部分で extras 不足
+
+```text
+ModuleNotFoundError: No module named 'altair'
+```
+
+**対処**: 既に `pip install -e ".[dev,all]"` で全 extras を入れる方針が CI に入っている。
+新しい extras 追加時は `pyproject.toml` の `all` meta extra にも反映 (R-recently issue で痛い目見た案件)。
+
+### 17. CI Rust 部分が `cargo test --all-features` で fail
+
+ローカル `cargo test --workspace` (all-features 無し) では通るのに CI で失敗するときは
+feature flag 違いの可能性。
+
+**対処**: ローカルで `cargo test --workspace --all-features` を再現。
+`scripts/check_ci_local.sh` が exact CI と同じコマンドを叩く。
+
+## 関連
+
+- [dev-setup](dev-setup.md) — 環境セットアップ
+- [REST API](../api/rest.md) — エラーレスポンス仕様
+- [各 algo doc](../algorithms/) — algorithm 固有エラーと対処

--- a/docs/executor/status.md
+++ b/docs/executor/status.md
@@ -1,0 +1,157 @@
+# 実装ステータス
+
+最終更新: 2026-05-04 (PR-1 〜 PR-8 マージ完了時点)
+
+## 全体進捗
+
+| Phase | 状態 |
+|---|---|
+| **80% プロトタイプ** (PR-1〜PR-8) | ✅ **完了** (`develop` マージ済) |
+| **Phase 3.5** (鍵管理 + Real signer + Real HL POST) | 未着手 (本ドキュメントの「残タスク」参照) |
+| **Phase 4** (本番運用 + observability + Auth) | 未着手 |
+
+## マージ済み PR (8 本)
+
+| PR | 内容 | merge SHA |
+|---|---|---|
+| [#58](https://github.com/howlrs/diff-old-new/pull/58) | PR-1 Cargo workspace + executor-core types | `be1d043` |
+| [#59](https://github.com/howlrs/diff-old-new/pull/59) | PR-2 executor-hl mock signer + WS state + TokenBucket + BatchSender | `2a87904` |
+| [#60](https://github.com/howlrs/diff-old-new/pull/60) | PR-3 Algorithm trait + MARKET (taker IOC) | `8cdb748` |
+| [#61](https://github.com/howlrs/diff-old-new/pull/61) | PR-4 PassiveFollowAlgorithm | `9b65830` |
+| [#62](https://github.com/howlrs/diff-old-new/pull/62) | PR-5 TwapAlgorithm + helper consolidation | `0f84efb` |
+| [#63](https://github.com/howlrs/diff-old-new/pull/63) | PR-6 MarketMakeAlgorithm | `52860cb` |
+| [#64](https://github.com/howlrs/diff-old-new/pull/64) | PR-7 axum REST + WS server | `5c81329` |
+| [#65](https://github.com/howlrs/diff-old-new/pull/65) | PR-8 emergency_stop + Python connector + e2e | `fcfd2ab` |
+
+## 実装済みコンポーネント
+
+### `executor-core` (22 tests)
+
+- [x] `Cloid` (uuid v7 → 0x + 32 hex)
+- [x] `Symbol` (HIP-3 dex 識別含む)
+- [x] `Address` / `Side` / `Tif` / `OrderId` / `Fill`
+- [x] `Intent` / `OrderIntent` / `CancelIntent` / `Progress` / `ExecutionReport`
+- [x] `AlgoParams` (`get_decimal` / `get_u32` 含む)
+- [x] `AppState` (book/position/open_orders/recent_fills/health/nonce 分割 lock)
+- [x] `NonceManager` (atomic counter + 100 件 rolling window)
+- [x] `AlgoError` / `ExecutorError`
+
+### `executor-hl` (17 tests)
+
+- [x] `Signer` trait + `MockSigner` (deterministic per-nonce 署名模擬)
+- [x] `TokenBucket` rate limiter (millisecond-precision atomic CAS, HoL fix)
+- [x] `BatchSender` (mpsc + 100ms flusher, order/cancel 分離, 個別 ack)
+- [x] `HlClient` trait + `MockHlClient` (calls 記録, oid 模擬値, account/book seed)
+- [x] `RealHlClient` 骨格 (signer + rate_limiter + reqwest, POST 本体は 80% プロト)
+- [x] `WsStateManager` (split-lock state 更新, partial fill aggregation, cancel/reject)
+
+### `executor-algo` (56 tests)
+
+- [x] `Algorithm` trait + `ExecutionContext`
+- [x] 共通 helpers: `drain_new_fills` / `taker_limit_price` / `ensure_book_fresh` / `collect_own_fills` / `build_report`
+- [x] `MarketAlgorithm` (taker IOC + slippage cap + partial-fill loop)
+- [x] `PassiveFollowAlgorithm` (maker ALO at touch + cancel/repost)
+- [x] `TwapAlgorithm` (時間スライス, child=market/passive, 累積目標方式)
+- [x] `MarketMakeAlgorithm` (target 駆動 2-sided ALO + inventory skew)
+
+### `executor-server` (18 tests)
+
+- [x] `ServerState` (Arc<AppState> + BatchSender + HlClient + Signer + Registry)
+- [x] `OrderRouter` (name → Box<dyn Algorithm>)
+- [x] `ExecutionRegistry` (HashMap<ExecutionId, Arc<RwLock<ExecutionHandle>>> + abort_all())
+- [x] REST: health / positions / book / start / status / cancel / emergency_stop
+- [x] WS: `/v1/exec/{id}/ws` (broadcast fan-out)
+- [x] `ServerError` (HTTP マップ + Internal masking)
+- [x] `ExecutionStatus::Finalizing` (race 対策中間 state)
+
+### `executor-cli`
+
+- [x] clap 4 derive, 7 サブコマンド
+- [x] `EXECUTOR_URL` env, `--params` JSON 引数
+
+### Python (`src/executor/`, 8 unit + 5 live tests)
+
+- [x] `ExecutorClient` (httpx async, REST + WS)
+- [x] `Algorithm` / `Intent` / `ExecutionStatus` (StrEnum, Rust serde 一致)
+- [x] `ExecutorClientError` (status + body)
+- [x] `tests/test_executor_client.py` (httpx.MockTransport で 8 ケース)
+- [x] `tests/test_executor_client_live.py` (subprocess.Popen で 5 e2e)
+
+## Gemini レビュー反映済み修正
+
+| PR | 主な反映 |
+|---|---|
+| 3 | stale book detection / `tokio::time::Instant` for paused-time |
+| 4 | partial-fill + book-move test |
+| 5 | drain_new_fills / taker_limit_price / ensure_book_fresh を algorithm.rs に集約 |
+| 6 | repost_bps_threshold=0 の warn / known limitations 明記 |
+| 7 | Finalizing 中間 status / Internal error masking / abort_all() |
+| 8 | cancel-before-abort 順序 / X-Operator-ID header |
+
+各レビュー結果は SurrealDB `review_log` (タグ `pr-N,gemini-review`) に保存済。
+
+## テスト集計
+
+| 区分 | 件数 |
+|---|---|
+| Rust (executor-core) | 22 |
+| Rust (executor-hl) | 17 |
+| Rust (executor-algo) | 56 |
+| Rust (executor-server unit) | 8 |
+| Rust (executor-server integration) | 10 |
+| **Rust 計** | **113** |
+| Python (既存 audit/strategy/etc) | 71 |
+| Python (executor connector) | 8 |
+| **Python (CI 対象) 計** | **79** |
+| Python (live e2e, marker live) | 5 |
+| **総計** | **197** |
+
+CI: `cargo fmt` / `cargo clippy -D warnings` / `ruff` / `mypy` / `scripts/check_ci_local.sh` 全クリーン。
+
+---
+
+## 残タスク (Phase 3.5 以降)
+
+### 必須 (本番投入の前提)
+
+| 項目 | 担当 | 備考 |
+|---|---|---|
+| 鍵管理ブレスト | TBD | agent wallet / master EOA / KMS / vault どれで鍵を持つか確定 |
+| `Eip712AgentSigner` 実装 | executor-hl | `secrecy::Secret` + `zeroize`, HL の typed-data 構造に合わせる |
+| `RealHlClient::place_orders` 完成 | executor-hl | POST `/exchange` payload + signature, レスポンス JSON parse |
+| `RealHlClient::cancel_orders` 完成 | executor-hl | 同上 |
+| Real WS subscriber | executor-hl | tokio-tungstenite で `wss://...`, 切断 + 5min reconcile |
+| `clearinghouseState` 完全 parse | executor-hl | 80% プロトでは骨格のみ |
+
+### 推奨 (本番品質)
+
+| 項目 | 内容 |
+|---|---|
+| Auth レイヤ (mTLS / SSO proxy) | executor-server を public に晒す前に必須 |
+| Observability | Prometheus exporter, Loki/Grafana, emergency_stop alert |
+| `ExecutionRegistry` の TTL/prune | 24h+ 連続稼働で完了済 entry 蓄積する問題への対処 |
+| `all_fills` の disk persist (MM) | 長時間 MM 用途。execution rotation で代替も可 |
+| connector の `X-Operator-ID` 渡し | Python から audit ID を渡せるように |
+| WS 再接続 / Lagged backoff (Python) | broadcast Lagged 後の自動再接続 |
+| Pydantic schema 中央化 | Rust serde ↔ Python 自動同期 (Gemini PR-8 deferred) |
+
+### 任意 (応用)
+
+| 項目 | 内容 |
+|---|---|
+| `tick_size` per symbol meta | PASSIVE/MM の `repost_threshold_ticks` 有効化 |
+| empty book backoff | 一時的な板スカに対する retry 戦略 (Gemini PR-4 deferred) |
+| 複数 process 並列稼働 | agent wallet × algorithm 種別ごとに独立プロセス |
+| MARKET の dynamic slippage | 直近 fill 結果で slippage を学習 |
+
+## 設計ドキュメント
+
+- 設計仕様 v2 (Gemini deep review 反映): [`../specs/2026-05-04-rust-executor-design.md`](../specs/2026-05-04-rust-executor-design.md)
+- 完了サマリ (SurrealDB output_log, タグ `rust,executor,8-pr-series,complete,80-percent`):  
+  `/home/o9oem/workspace/surreal-query.sh --search "8-pr-series complete"`
+
+## 関連
+
+- [README](README.md) — 全体目次
+- [architecture](architecture.md) — 実装後の構造
+- [deployment](operations/deployment.md) — 本番投入前チェックリスト

--- a/docs/phase-1-report.md
+++ b/docs/phase-1-report.md
@@ -3,6 +3,9 @@
 最終更新: 2026-05-04
 Tag: `v0.1.0`
 
+> **追記 (2026-05-04)**: Phase 3 の中で **Rust executor 80% プロトタイプ** が完了 (PR-1〜PR-8).
+> 詳細は [`executor/`](executor/README.md) を参照. 鍵管理 + 実 HL POST のみ未実装.
+
 ## ビジョン (再掲)
 オールド金融 (CME/NYSE/NASDAQ) と新金融 (Hyperliquid HIP-3 / Trade[XYZ]) の **構造的接続点と切断点** を観測し、繰り返し可能な統計的優位 (LLN/CLT) を発見・収益化する.
 


### PR DESCRIPTION
## Summary
PR-1〜PR-8 (Rust executor 80% プロトタイプ) の利用者向け資料を `docs/executor/` 配下に整備。日本語で 13 ファイル / 2348 行。

## 構成
```
docs/executor/
├── README.md                    全体目次
├── architecture.md              workspace 構造 + データフロー
├── status.md                    実装ステータス + 残タスク
├── cli.md                       executor-cli ガイド
├── algorithms/
│   ├── market.md
│   ├── passive_follow.md
│   ├── twap.md
│   └── market_make.md
├── api/
│   ├── rest.md                  7 endpoint 全仕様 (req/res + エラー)
│   └── websocket.md             Progress event スキーマ
├── connector/
│   └── python.md                src/executor/ 利用ガイド
└── operations/
    ├── dev-setup.md             環境構築 + テスト
    ├── deployment.md            本番投入前チェックリスト
    └── troubleshooting.md       17 ケース
```

## 内容ハイライト
- 4 algorithm 全ての AlgoParams 表 + ユースケース別パラメータ例 + 終了条件
- Python connector の使い方サンプル 3 種 (REST polling / WS streaming / kill switch)
- 本番投入前チェックリスト: 鍵管理 / Real signer / Real HL POST / Auth / observability
- 各 PR の Gemini レビュー反映点表

## リンク検証
- 全 internal link resolve OK (Python script で機械検証済)
- `README.md` + `docs/phase-1-report.md` に executor 完了の追記とリンク追加

## Test plan
- [x] markdown 内部リンク全て resolve (機械検証)
- [x] `scripts/check_ci_local.sh` — All checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)