### PR TITLE
docs: 引き継ぎメモ + Phase 3.5 TODO チェックリスト

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ Hyperliquid (HIP-3 / Trade[XYZ]) 上の **米株指数 perpetual** と **オー�
 ## ステータス
 **Data audit pipeline 完備 (v0.4.0)** — Phase 1 詳細: [`docs/phase-1-report.md`](docs/phase-1-report.md), 履歴: [CHANGELOG](CHANGELOG.md)
 
+**Phase 3 進捗**: Rust executor 80% プロトタイプ完了 (PR-1〜PR-8 + docs).
+次セッション着手は [`docs/HANDOFF-2026-05-04.md`](docs/HANDOFF-2026-05-04.md) と [`docs/TODO.md`](docs/TODO.md) を参照.
+
 **HL Oracle 信頼性実証**: BTC oracle が外部 CEX (Binance:OKX:Bybit weighted median) と相関 **0.9792**, median diff -0.18bps → 戦略の前提が信頼に足ることを実データで実証.
 
 - [x] Phase 0: HL 仕様調査 完了 (`docs/specs/2026-05-04-phase0-spec-notes.md`)

--- a/docs/HANDOFF-2026-05-04.md
+++ b/docs/HANDOFF-2026-05-04.md
@@ -1,0 +1,335 @@
+# 引き継ぎメモ (2026-05-04)
+
+> このセッションで完了した作業と、次に着手すべきタスクの引き継ぎ資料。
+> 次セッションはこのファイルから読み始めれば文脈を取り戻せる。
+
+## 1. 今セッションで完了したもの
+
+### Rust executor 80% プロトタイプ (PR-1 〜 PR-8) — 全マージ済
+
+| PR | branch | 内容 | merged SHA |
+|---|---|---|---|
+| [#58](https://github.com/howlrs/diff-old-new/pull/58) | feat/pr1-rust-workspace | Cargo workspace + executor-core types | `be1d043` |
+| [#59](https://github.com/howlrs/diff-old-new/pull/59) | feat/pr2-rust-hl | mock signer + WS state + TokenBucket + BatchSender | `2a87904` |
+| [#60](https://github.com/howlrs/diff-old-new/pull/60) | feat/pr3-rust-algo-market | Algorithm trait + MARKET (taker IOC) | `8cdb748` |
+| [#61](https://github.com/howlrs/diff-old-new/pull/61) | feat/pr4-rust-algo-passive-follow | PassiveFollowAlgorithm | `9b65830` |
+| [#62](https://github.com/howlrs/diff-old-new/pull/62) | feat/pr5-rust-algo-twap | TwapAlgorithm + helper consolidation | `0f84efb` |
+| [#63](https://github.com/howlrs/diff-old-new/pull/63) | feat/pr6-rust-algo-market-make | MarketMakeAlgorithm | `52860cb` |
+| [#64](https://github.com/howlrs/diff-old-new/pull/64) | feat/pr7-rust-executor-server | axum REST + WS server | `5c81329` |
+| [#65](https://github.com/howlrs/diff-old-new/pull/65) | feat/pr8-emergency-stop-and-connector | emergency_stop + Python connector + e2e | `fcfd2ab` |
+
+### 日本語ドキュメント整備
+
+| PR | branch | 内容 | merged SHA |
+|---|---|---|---|
+| [#66](https://github.com/howlrs/diff-old-new/pull/66) | docs/executor-japanese-references | docs/executor/ 13 files / 2348 lines | `feec7a6` |
+
+### テスト集計 (現時点)
+
+| 区分 | 件数 |
+|---|---|
+| Rust (executor-core) | 22 |
+| Rust (executor-hl) | 17 |
+| Rust (executor-algo) | 56 |
+| Rust (executor-server unit) | 8 |
+| Rust (executor-server integration) | 10 |
+| **Rust 計** | **113** |
+| Python (CI 対象) | 79 |
+| Python (live e2e, marker `live`) | 5 |
+| **総計** | **197** |
+
+`cargo fmt` / `cargo clippy -D warnings` / `ruff` / `mypy` / `scripts/check_ci_local.sh` 全クリーン。
+
+---
+
+## 2. 次セッションの着手順 (優先度順)
+
+### Step A: 鍵管理ブレスト ⭐ 最優先
+
+ユーザーから「鍵系は保留」「個人情報系の詳細をつめ、実注文などのテストを行いましょう」と指示済。
+Phase 3.5 着手の最初のステップ。
+
+#### 検討する論点
+
+1. **鍵保持場所**:
+   - env (`HL_AGENT_PRIVKEY=0x...`) → シンプルだが揮発前提
+   - vault (HashiCorp Vault / 1Password CLI 等) → 取得コスト
+   - 暗号化ファイル (age / sops + age) → 静止時暗号化
+   - HSM / KMS (Cloud KMS) → 過剰スペック?
+2. **agent wallet 構造**:
+   - master EOA = ユーザー主鍵 (証拠金移動可)
+   - agent wallet = HL `approveAgent` で承認した派生鍵 (発注のみ)
+   - **方針**: 1 algorithm × 1 symbol = 1 agent wallet で分離 (nonce 競合 + 被害局所化)
+3. **deregister 手順**:
+   - 通常停止: HL `approveAgent(... validUntil=now)` で即時失効
+   - 漏洩時: master EOA から強制 deregister + 新 agent 発行
+4. **メモリ衛生**:
+   - `secrecy::Secret<[u8; 32]>` で平文保持禁止
+   - `zeroize::Zeroize` で drop 時クリア
+   - panic 時の心配 → `panic = "abort"` (release profile 既設定)
+5. **rotation policy**:
+   - 24h 毎 / 1 週間毎 のローテ自動化?
+   - 起動時 graceful refresh
+
+#### Gemini にレビューさせる項目
+
+```bash
+echo "鍵管理設計案 ..." | ~/.claude/hooks/gemini-review.sh deep
+```
+
+決まったら `docs/specs/2026-05-MM-key-management-design.md` を起こす。
+
+### Step B: `Eip712AgentSigner` 実装
+
+`executor-hl/src/signer.rs` に `MockSigner` の代わりとなる実 EIP-712 signer を実装。
+
+#### 実装ポイント
+
+- `Signer::sign_l1` の中身を埋める
+- HL `/exchange` の typed-data 構造 (`HyperliquidTransaction:Withdraw`, `HyperliquidTransaction:UsdSend` 等)
+  に正確に合わせる。**仕様再確認は HL python-sdk 0.23.0 のソースが正解**
+- `secrecy::Secret<...>` で秘密鍵を保持
+- 単体テスト: 既知 nonce + msg → 既知 signature (HL python-sdk と cross-check)
+
+参考実装:
+- HL python-sdk `hyperliquid/utils/signing.py`
+- `executor-hl/src/signer.rs` の `MockSigner` (deterministic 模擬)
+
+### Step C: `RealHlClient::place_orders` / `cancel_orders` 完成
+
+`executor-hl/src/hl_client.rs` の `RealHlClient` impl を完成させる。
+
+#### 実装ポイント
+
+- `POST /exchange` の payload schema:
+  ```json
+  {
+    "action": { "type": "order", "orders": [...], "grouping": "na" },
+    "nonce": 1234567890123,
+    "signature": { "r": "...", "s": "...", "v": 27 },
+    "vaultAddress": null
+  }
+  ```
+- レスポンス JSON (`status`, `response.data.statuses[].resting/filled/error`) のパース
+- 部分約定や resting oid を `OrderResponse` に抽出
+- レート制限が来たら `HlError::RateLimited { wait_ms }` で返す
+- `MockHlClient` のテストは production と同じ trait を share してるので追加不要
+
+### Step D: Real WS subscriber
+
+`executor-hl/src/ws_state.rs` の `WsStateManager` はステート変換ロジックのみ。
+別タスクとして実 WS 接続を実装。
+
+#### 実装ポイント
+
+- `tokio-tungstenite` で `wss://api.hyperliquid.xyz/ws`
+- subscribe メッセージ: `{"method":"subscribe","subscription":{"type":"l2Book","coin":"BTC"}}` 等
+- 切断検知 + 指数バックオフ (例: 200ms → 30s, 30s 安定で reset)
+- 起動時 + 再接続後 + 5min 周期で REST `clearinghouseState` を叩いて AppState reconcile
+- WS message → `WsStateManager::apply()` で AppState に反映
+
+### Step E: Auth レイヤ (本番投入前必須)
+
+`executor-server` 自身に Auth は組み込まない。前段 reverse proxy で:
+
+- mTLS or SSO/JWT
+- proxy が `X-Operator-ID` を Auth 結果から付与
+- rate limit を proxy で
+
+サンプル: nginx + auth_request, Caddy + JWT plugin, あるいは Tailscale ACL 経由。
+
+### Step F: testnet smoke (Phase 3.5 完成判定)
+
+testnet で 1 ラウンドずつ:
+- MARKET で 0.001 BTC open → close
+- PASSIVE で 0.001 BTC open
+- TWAP で 0.001 BTC を 5 slice で open
+- MARKET_MAKE で target=0 / current=0 → 5 分動かして両側 quote が並ぶことを確認
+- `POST /v1/emergency_stop` で全 cancel が走ることを fill log で検証
+
+---
+
+## 3. 個別の小さな TODO (優先度低)
+
+このセッション中に Gemini レビューで deferred したもの。Phase 3.5 着手と並行で OK:
+
+### 3.1 Python connector の `X-Operator-ID` サポート (PR-8 deferred)
+
+`src/executor/client.py` の `ExecutorClient` に `operator_id: str | None = None` を追加。
+`_post` で header 付与。
+emergency_stop 時の audit に必要。
+
+### 3.2 ExecutionRegistry の TTL/prune (PR-7 review)
+
+`executor-server/src/registry.rs` の `ExecutionRegistry` に `prune_completed(older_than: Duration)` 追加。
+24h+ 連続稼働で完了済 entry が蓄積する問題への対処。
+
+### 3.3 broadcast 容量を増やす (PR-7 review)
+
+`executor-server/src/routes.rs:103` の `broadcast::channel::<Progress>(256)` を 1024 等に。
+高頻度 MM での Lagged 多発を抑える。
+
+### 3.4 WS 再接続 / Lagged backoff (Python connector, PR-8 review)
+
+`src/executor/client.py` の `stream()` に再接続ループを追加。
+`websockets` の close を catch → 指数バックオフで reconnect。
+broadcast Lagged 後の自動再開に必要。
+
+### 3.5 `tick_size` per symbol meta (PR-4 deferred)
+
+`executor-core/src/symbol.rs` に tick_size を持たせて `passive_follow.rs` の
+`repost_threshold_ticks` を有効化。HL `info` API から取得して起動時 cache。
+
+### 3.6 MARKET_MAKE の `all_fills` rotation (PR-6 known limitation)
+
+長時間 MM で `all_fills: Vec<Fill>` が拡張無制限。
+- 案 A: server 側で execution を ~1h ごとに自動 rotate
+- 案 B: `executor-algo` 内で `all_fills` を bounded ring buffer 化
+
+### 3.7 empty book backoff (PR-4 review)
+
+`market: empty asks (no best ask)` で即 abort せず, 短時間 retry してから abort する戦略。
+WS 一時切断時の復旧待ち用途。
+
+### 3.8 Pydantic schema 中央化 (PR-8 review)
+
+Rust serde ↔ Python の wire 一致を手書き StrEnum で維持しているのを
+Pydantic + alias_generator で自動化。連携対象が増えたタイミングで検討。
+
+---
+
+## 4. 開発再開のチェックリスト
+
+次セッション冒頭でやること:
+
+```bash
+# 1. develop に同期
+cd /home/o9oem/workspace/crypto/diff-old-new
+git checkout develop
+git pull --rebase
+
+# 2. ビルドが通ることを確認
+cd executor && cargo build --workspace
+cargo test --workspace
+cd ..
+
+# 3. Python venv も最新化
+source .venv/bin/activate
+pip install -e ".[dev,all]"
+
+# 4. ローカル CI を念のため
+bash scripts/check_ci_local.sh
+```
+
+何か壊れていたら develop に戻して状態を確認。
+
+---
+
+## 5. 重要ファイルのリンク集
+
+### 設計ドキュメント
+
+- [Rust executor design v2](specs/2026-05-04-rust-executor-design.md) — Gemini deep review 反映済
+- [v3 system design](specs/2026-05-04-v3-design.md) — Phase 0 から続く全体像
+- [Phase 0 HL 仕様調査](specs/2026-05-04-phase0-spec-notes.md)
+- [Phase 1 完了レポート](phase-1-report.md)
+
+### Executor ドキュメント (今セッションで整備)
+
+- [`docs/executor/README.md`](executor/README.md) — 全体目次
+- [`docs/executor/architecture.md`](executor/architecture.md) — 実装後の構造
+- [`docs/executor/status.md`](executor/status.md) — 実装済 / 残タスクの最新一覧
+- [`docs/executor/api/rest.md`](executor/api/rest.md) — REST 7 endpoint
+- [`docs/executor/api/websocket.md`](executor/api/websocket.md) — Progress 6 variant
+- [`docs/executor/algorithms/`](executor/algorithms/) — 4 algo 仕様
+- [`docs/executor/operations/deployment.md`](executor/operations/deployment.md) — 本番投入チェックリスト
+- [`docs/executor/operations/troubleshooting.md`](executor/operations/troubleshooting.md) — 17 ケース
+
+### コード起点
+
+- workspace root: `executor/Cargo.toml`
+- 算法 trait: `executor/crates/executor-algo/src/algorithm.rs`
+- HL 通信: `executor/crates/executor-hl/src/hl_client.rs`
+- 鍵 (Mock のみ): `executor/crates/executor-hl/src/signer.rs`
+- サーバ起動: `executor/crates/executor-server/src/main.rs`
+- Python connector: `src/executor/client.py`
+- e2e fixture: `tests/test_executor_client_live.py`
+
+### 自動化スクリプト
+
+- ローカル CI 再現: `scripts/check_ci_local.sh`
+- Gemini レビュー: `~/.claude/hooks/gemini-review.sh {qa|review|deep|error|issue|image}`
+- SurrealDB 操作: `~/workspace/surreal-query.sh --help`
+
+### SurrealDB に保存済の知見
+
+- `review_log` (タグ `pr-N,gemini-review`): 各 PR の Gemini レビュー結果
+- `output_log` (タグ `8-pr-series,complete,80-percent`): 完了サマリ
+- `output_log` (タグ `documentation,japanese,phase-3-complete`): 日本語ドキュメント整備サマリ
+- `knowledge` (検索 `executor`): 設計上の確定事項
+
+検索例:
+```bash
+~/workspace/surreal-query.sh --search "executor 8-pr-series" --table all --limit 10
+~/workspace/surreal-query.sh --review-create  # 新規レビュー記録
+```
+
+---
+
+## 6. 既知の落とし穴 (このセッションで踏んだ罠)
+
+次セッションで同じ罠を踏まないように:
+
+### 6.1 `tokio::time::pause()` テストで `std::time::Instant`
+
+`tokio::time::pause()` で paused-time テスト中, `std::time::Instant::now()` は **実時間** を返すため
+deadline が永遠に経過しない。長時間 loop で deadline 計測する場合は **必ず `tokio::time::Instant`** を使う。
+PR-3 の `algorithm.rs:collect_own_fills` で 1 度ハマった。
+
+### 6.2 `cd` で workspace を見失う
+
+`executor/` 配下が Cargo workspace ルート。`cd /home/o9oem/workspace/crypto/diff-old-new` の状態で
+`cargo` を打つと `could not find Cargo.toml` で死ぬ。 `cd executor` を忘れない。
+
+### 6.3 clippy `expect_used` / `unwrap_used`
+
+production code で `unwrap()` / `expect()` 使うと `cargo clippy -D warnings` で fail。
+- production: 適切にエラー伝播
+- test: モジュール冒頭に `#![allow(clippy::unwrap_used, clippy::expect_used)]`
+
+### 6.4 CI で extras 不足 (Python)
+
+`pyproject.toml` の `dev` だけで `[all]` に新 extras を反映し忘れると CI が
+`ModuleNotFoundError: altair` 等で死ぬ。新 extras 追加時は必ず `[all]` メタ extra にも追記。
+
+### 6.5 emergency_stop は cancel-then-abort
+
+順序逆だと, abort 信号到達前に algo が新規 order を enqueue する余地が残る。
+Gemini PR-8 で指摘されて修正済 (`executor-server/src/routes.rs::emergency_stop`)。
+
+### 6.6 maker side の touch 選択
+
+PASSIVE_FOLLOW で `Close-Short` は `side=Long` (買い戻し) になるため, **best_bid に並ぶ**。
+直感的に "売りに引っかけたい" と思いがちだが, maker は反対側に立つ。
+PR-4 のテストで 1 度間違えた (`first.px=2001` を期待して 2000 が来た)。
+
+### 6.7 markdown 内部リンクの `../`
+
+`docs/executor/cli.md` から `tests/test_executor_client_live.py` は `../../tests/...` (`docs/` → `repo root` → `tests/`)。
+`../../../` だと `/home/o9oem/workspace/crypto/tests/...` まで上がってしまい broken。
+PR-66 で 1 件踏んだ。検証スクリプトはセッション 5 章末の Python script 参照。
+
+---
+
+## 7. 連絡事項 (将来 Claude へ)
+
+- ユーザー (gonumb66@gmail.com) は **Gemini パートナーレビュー** を非常に重視している。
+  「分かりました」「OK」と返ってこなくても, **重要決定の前に必ず Gemini deep / review を回す**。
+- ユーザーは **CI を何度も失敗させること** を嫌う (実績あり)。
+  push 前に必ず `scripts/check_ci_local.sh` を回すこと。
+- ユーザーは曖昧指示を嫌う。**Claude が推奨を 1 つ選び, Gemini 合議で齟齬がなければ自動進行**
+  (CLAUDE.md K1 ルール)。
+- 80% プロト範囲では **MockHlClient + MockSigner で keyless 動作する範囲のみ実装**。
+  鍵が要る部分は躊躇なく "次セッションで" と保留する。
+
+完。

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,0 +1,82 @@
+# TODO (Phase 3.5 以降)
+
+最終更新: 2026-05-04 (PR-1 〜 PR-8 + docs PR-66 完了時点)
+詳細な引き継ぎ: [`HANDOFF-2026-05-04.md`](HANDOFF-2026-05-04.md)
+
+## 必須 (本番投入の前提)
+
+- [ ] **A. 鍵管理ブレスト** ⭐ 最優先  
+      検討: 鍵保持場所 / agent wallet 構造 / deregister 手順 / メモリ衛生 / rotation policy  
+      → `docs/specs/2026-05-MM-key-management-design.md` を起こす  
+      Gemini deep レビュー必須
+
+- [ ] **B. `Eip712AgentSigner` 実装** (`executor-hl/src/signer.rs`)  
+      - HL `/exchange` の typed-data 構造 (HL python-sdk 0.23.0 がリファレンス)  
+      - `secrecy::Secret<...>` で秘密鍵保持  
+      - 単体テスト: 既知 nonce + msg → 既知 signature (HL python-sdk と cross-check)
+
+- [ ] **C. `RealHlClient::place_orders` / `cancel_orders` 完成** (`executor-hl/src/hl_client.rs`)  
+      - POST /exchange の payload schema 確定  
+      - レスポンス JSON parse (oid 抽出, error mapping)  
+      - rate-limited 時の `HlError::RateLimited { wait_ms }`
+
+- [ ] **D. Real WS subscriber** (`executor-hl/src/ws_state.rs` の上に新規ファイル想定)  
+      - `tokio-tungstenite` で `wss://api.hyperliquid.xyz/ws`  
+      - 切断検知 + 指数バックオフ (200ms→30s, 30s 安定で reset)  
+      - 起動時 + 再接続後 + 5min 周期で `clearinghouseState` reconcile
+
+- [ ] **E. Auth レイヤ (前段 reverse proxy)**  
+      - mTLS or SSO/JWT  
+      - proxy で `X-Operator-ID` 自動付与  
+      - executor-server を public に晒さない方針を運用 doc 化
+
+- [ ] **F. testnet smoke** (Phase 3.5 完成判定)  
+      - MARKET / PASSIVE / TWAP / MM 各 1 ラウンド  
+      - `POST /v1/emergency_stop` の testnet 実走
+
+## 推奨 (Phase 3.5 と並行可)
+
+- [ ] **3.1 Python connector の `X-Operator-ID` サポート**  
+      `src/executor/client.py` の `ExecutorClient` に `operator_id` パラメータ追加 (PR-8 deferred)
+
+- [ ] **3.2 ExecutionRegistry の TTL/prune** (PR-7 review)  
+      `executor-server/src/registry.rs` に `prune_completed(older_than)` 追加
+
+- [ ] **3.3 broadcast 容量を増やす** (PR-7 review)  
+      `executor-server/src/routes.rs:103` の `broadcast::channel(256)` を 1024 等へ
+
+- [ ] **3.4 WS 再接続 / Lagged backoff (Python connector)** (PR-8 review)  
+      `src/executor/client.py` の `stream()` に再接続ループ追加
+
+- [ ] **3.5 `tick_size` per symbol meta** (PR-4 deferred)  
+      `executor-core/src/symbol.rs` に tick_size を持たせて  
+      `passive_follow.rs` の `repost_threshold_ticks` を有効化
+
+- [ ] **3.6 MARKET_MAKE の `all_fills` rotation** (PR-6 known limitation)  
+      案 A: server 側で execution を ~1h ごとに自動 rotate  
+      案 B: `all_fills` を bounded ring buffer 化
+
+## 任意 (応用)
+
+- [ ] **3.7 empty book backoff** (PR-4 review)  
+      `market: empty asks (no best ask)` で即 abort せず短時間 retry してから abort
+
+- [ ] **3.8 Pydantic schema 中央化** (PR-8 review)  
+      Rust serde ↔ Python の wire 一致を Pydantic + alias_generator で自動化
+
+- [ ] **3.9 観測性 (observability)**  
+      - `tracing-subscriber` JSON formatter → Loki/Grafana  
+      - Prometheus exporter (P50/P99 レイテンシ, batch flush 数, fill 数)  
+      - `emergency_stop` 実行時の Slack/PagerDuty alert
+
+- [ ] **3.10 複数プロセス並列稼働**  
+      agent wallet × algorithm 種別ごとに独立プロセス起動
+
+- [ ] **3.11 MARKET の dynamic slippage**  
+      直近 fill 結果から slippage を学習
+
+## 完了済み (この履歴)
+
+- [x] PR-1〜PR-8: Rust executor 80% プロトタイプ (`executor/`)
+- [x] PR-66: `docs/executor/` 日本語ドキュメント整備
+- [x] HANDOFF-2026-05-04.md: 本ファイル + 引き継ぎメモ

--- a/docs/executor/README.md
+++ b/docs/executor/README.md
@@ -7,6 +7,10 @@ Hyperliquid (HIP-3 / Trade[XYZ]) への注文執行レイヤ (`executor/` 以下
 > 鍵管理 (`secrecy` / `zeroize` 統合, 実 EIP-712 signer) と HL への実 POST `/exchange` 以外
 > は全て実装済み。`MockHlClient` + `MockSigner` で keyless にエンドツーエンド動作する。
 
+> **次セッション着手時はまずこちら**:
+> - 引き継ぎメモ: [`../HANDOFF-2026-05-04.md`](../HANDOFF-2026-05-04.md)
+> - TODO チェックリスト: [`../TODO.md`](../TODO.md)
+
 ## 主要ドキュメント
 
 | 区分 | ファイル | 内容 |


### PR DESCRIPTION
## Summary
セッション終了時の引き継ぎ資料を `docs/` 配下に整備。次セッションはこのファイルから読み始めれば文脈を取り戻せる。

## 新規ファイル

### `docs/HANDOFF-2026-05-04.md`
詳細な引き継ぎメモ:
- 完了済 PR-1〜PR-8 + PR-66 の一覧 (merged SHA 付)
- **次セッションの着手順** (Step A-F: 鍵管理 → testnet smoke)
- 個別 TODO 8 件 (各 Gemini レビューで deferred されたもの)
- 開発再開チェックリスト
- 重要ファイルへのリンク集
- **既知の落とし穴 7 件** (このセッションで踏んだ罠)
- 将来 Claude への連絡事項 (ユーザー指示の傾向 等)

### `docs/TODO.md`
機械可読チェックリスト:
- 必須 6 件 (Phase 3.5 本番投入の前提)
- 推奨 6 件 (並行可能)
- 任意 5 件 (応用)

## 更新

- `README.md`: Phase 3 進捗の追記 + HANDOFF/TODO へのリンク
- `docs/executor/README.md`: 冒頭に HANDOFF/TODO リンク

## 検証
- markdown 内部リンク全件 resolve OK
- `scripts/check_ci_local.sh` All checks passed
- SurrealDB output_log にも保存済 (`handoff,phase-3.5-todo,key-management-pending`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)