### PR TITLE
feat(executor-hl): PR-B2a — place_orders/cancel_orders + mockito + 10/10 cross-check

### DIFF
--- a/docs/HANDOFF-2026-05-04.md
+++ b/docs/HANDOFF-2026-05-04.md
@@ -106,6 +106,19 @@ echo "鍵管理設計案 ..." | ~/.claude/hooks/gemini-review.sh deep
   クロスチェックは `norm_hex32` で normalize して合致確認. 本番 `/exchange` POST 時に
   HL がどちらを accept するかは PR-B2 で実 testnet 検証.
 
+#### 2026-05-05 PR-B2a 完了
+
+- `RealHlClient::place_orders` / `cancel_orders` 本実装完了 (`hl_client.rs`)
+- `Signer::sign_l1` に `vault: Option<&Address>` 引数追加 → vault cross-check 2 件 enable で **10/10 byte-identical**
+- `eip712.rs` に `CancelByCloidAction` / `CancelByCloidWire` (asset 全名, cloid) 追加 + `order_intent_to_wire` ヘルパー
+- `OrderIntent` / `CancelIntent` に `pub asset: u32` field 追加 (executor-algo の 21 caller を asset:0 placeholder + // TODO(PR-B2b) で移行)
+- mockito 1.7.2 dev-dep + 7 mock backend test (resting/filled/error/top-err/empty/cancel-success/by-oid-reject)
+- `cancelByCloid` のみ実装. `by_oid` cancel は `HlError::ActionFormat` で reject (PR-B2a スコープ)
+- 141 workspace tests pass
+- **PR-B2b に持ち越し**: r/s padding の実 HL 検証 (testnet smoke), `OrderIntent.asset` の symbol→index 動的解決 (fetch_meta cache), vault 引数を place_orders/cancel_orders 自体に plumb
+
+### Step C: `RealHlClient::place_orders` / `cancel_orders` 完成
+
 ### Step C: `RealHlClient::place_orders` / `cancel_orders` 完成
 
 `executor-hl/src/hl_client.rs` の `RealHlClient` impl を完成させる。

--- a/executor/Cargo.lock
+++ b/executor/Cargo.lock
@@ -710,6 +710,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1094,6 +1104,15 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "colored"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "combine"
@@ -1522,6 +1541,7 @@ dependencies = [
  "futures",
  "hex",
  "mockall",
+ "mockito",
  "proptest",
  "reqwest",
  "rmp-serde",
@@ -1837,6 +1857,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.14.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1962,6 +2001,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -2492,6 +2532,31 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "mockito"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90820618712cab19cfc46b274c6c22546a82affcb3c3bdf0f29e3db8e1bb92c0"
+dependencies = [
+ "assert-json-diff",
+ "bytes",
+ "colored",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "pin-project-lite",
+ "rand 0.9.4",
+ "regex",
+ "serde_json",
+ "serde_urlencoded",
+ "similar",
+ "tokio",
 ]
 
 [[package]]
@@ -3752,6 +3817,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4055,6 +4126,19 @@ dependencies = [
  "tokio-rustls",
  "tungstenite",
  "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]

--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -63,6 +63,7 @@ zeroize = { version = "1", features = ["zeroize_derive"] }
 mockall = "0.13"
 proptest = "1"
 rstest = "0.24"
+mockito = "1.7.2"
 
 # Internal crates (path)
 executor-core = { path = "crates/executor-core" }

--- a/executor/crates/executor-algo/src/market.rs
+++ b/executor/crates/executor-algo/src/market.rs
@@ -277,6 +277,8 @@ impl Algorithm for MarketAlgorithm {
             let order = OrderIntent {
                 cloid,
                 symbol: ctx.symbol.clone(),
+                // TODO(PR-B2b): resolve via meta cache (currently placeholder)
+                asset: 0,
                 side,
                 px: limit_px,
                 sz: remaining,

--- a/executor/crates/executor-algo/src/market_make.rs
+++ b/executor/crates/executor-algo/src/market_make.rs
@@ -285,6 +285,8 @@ impl Algorithm for MarketMakeAlgorithm {
             if let Some(c) = q.cloid.take() {
                 let _ = ctx.batch.enqueue(OrderOrCancel::Cancel(CancelIntent {
                     symbol: ctx.symbol.clone(),
+                    // TODO(PR-B2b): resolve via meta cache (currently placeholder)
+                    asset: 0,
                     by_cloid: Some(c),
                     by_oid: None,
                 }));
@@ -386,6 +388,8 @@ impl Algorithm for MarketMakeAlgorithm {
                     let order = OrderIntent {
                         cloid,
                         symbol: ctx.symbol.clone(),
+                        // TODO(PR-B2b): resolve via meta cache (currently placeholder)
+                        asset: 0,
                         side: Side::Long,
                         px: bid_px,
                         sz: desired_bid_sz,
@@ -416,6 +420,8 @@ impl Algorithm for MarketMakeAlgorithm {
                     let order = OrderIntent {
                         cloid,
                         symbol: ctx.symbol.clone(),
+                        // TODO(PR-B2b): resolve via meta cache (currently placeholder)
+                        asset: 0,
                         side: Side::Short,
                         px: ask_px,
                         sz: desired_ask_sz,

--- a/executor/crates/executor-algo/src/passive_follow.rs
+++ b/executor/crates/executor-algo/src/passive_follow.rs
@@ -175,6 +175,8 @@ impl Algorithm for PassiveFollowAlgorithm {
                 if let Some((c, _)) = current_quote.take() {
                     let _ = ctx.batch.enqueue(OrderOrCancel::Cancel(CancelIntent {
                         symbol: ctx.symbol.clone(),
+                        // TODO(PR-B2b): resolve via meta cache (currently placeholder)
+                        asset: 0,
                         by_cloid: Some(c),
                         by_oid: None,
                     }));
@@ -193,6 +195,8 @@ impl Algorithm for PassiveFollowAlgorithm {
                 if let Some((c, _)) = current_quote.take() {
                     let _ = ctx.batch.enqueue(OrderOrCancel::Cancel(CancelIntent {
                         symbol: ctx.symbol.clone(),
+                        // TODO(PR-B2b): resolve via meta cache (currently placeholder)
+                        asset: 0,
                         by_cloid: Some(c),
                         by_oid: None,
                     }));
@@ -233,6 +237,8 @@ impl Algorithm for PassiveFollowAlgorithm {
                 if let Some((c, _)) = current_quote.take() {
                     let _ = ctx.batch.enqueue(OrderOrCancel::Cancel(CancelIntent {
                         symbol: ctx.symbol.clone(),
+                        // TODO(PR-B2b): resolve via meta cache (currently placeholder)
+                        asset: 0,
                         by_cloid: Some(c),
                         by_oid: None,
                     }));
@@ -260,6 +266,8 @@ impl Algorithm for PassiveFollowAlgorithm {
                 if let Some((c, _)) = current_quote.take() {
                     let _ = ctx.batch.enqueue(OrderOrCancel::Cancel(CancelIntent {
                         symbol: ctx.symbol.clone(),
+                        // TODO(PR-B2b): resolve via meta cache (currently placeholder)
+                        asset: 0,
                         by_cloid: Some(c),
                         by_oid: None,
                     }));
@@ -269,6 +277,8 @@ impl Algorithm for PassiveFollowAlgorithm {
                 let order = OrderIntent {
                     cloid,
                     symbol: ctx.symbol.clone(),
+                    // TODO(PR-B2b): resolve via meta cache (currently placeholder)
+                    asset: 0,
                     side,
                     px: new_touch,
                     sz: remaining,

--- a/executor/crates/executor-algo/src/twap.rs
+++ b/executor/crates/executor-algo/src/twap.rs
@@ -200,6 +200,8 @@ impl Algorithm for TwapAlgorithm {
                 if let Some(c) = current_passive_quote.take() {
                     let _ = ctx.batch.enqueue(OrderOrCancel::Cancel(CancelIntent {
                         symbol: ctx.symbol.clone(),
+                        // TODO(PR-B2b): resolve via meta cache (currently placeholder)
+                        asset: 0,
                         by_cloid: Some(c),
                         by_oid: None,
                     }));
@@ -218,6 +220,8 @@ impl Algorithm for TwapAlgorithm {
                 if let Some(c) = current_passive_quote.take() {
                     let _ = ctx.batch.enqueue(OrderOrCancel::Cancel(CancelIntent {
                         symbol: ctx.symbol.clone(),
+                        // TODO(PR-B2b): resolve via meta cache (currently placeholder)
+                        asset: 0,
                         by_cloid: Some(c),
                         by_oid: None,
                     }));
@@ -257,6 +261,8 @@ impl Algorithm for TwapAlgorithm {
             if let Some(c) = current_passive_quote.take() {
                 let _ = ctx.batch.enqueue(OrderOrCancel::Cancel(CancelIntent {
                     symbol: ctx.symbol.clone(),
+                    // TODO(PR-B2b): resolve via meta cache (currently placeholder)
+                    asset: 0,
                     by_cloid: Some(c),
                     by_oid: None,
                 }));
@@ -270,6 +276,8 @@ impl Algorithm for TwapAlgorithm {
                     let order = OrderIntent {
                         cloid,
                         symbol: ctx.symbol.clone(),
+                        // TODO(PR-B2b): resolve via meta cache (currently placeholder)
+                        asset: 0,
                         side,
                         px: limit_px,
                         sz: slice_target_remaining,
@@ -299,6 +307,8 @@ impl Algorithm for TwapAlgorithm {
                     let order = OrderIntent {
                         cloid,
                         symbol: ctx.symbol.clone(),
+                        // TODO(PR-B2b): resolve via meta cache (currently placeholder)
+                        asset: 0,
                         side,
                         px: touch,
                         sz: slice_target_remaining,
@@ -365,6 +375,8 @@ impl Algorithm for TwapAlgorithm {
         if let Some(c) = current_passive_quote.take() {
             let _ = ctx.batch.enqueue(OrderOrCancel::Cancel(CancelIntent {
                 symbol: ctx.symbol.clone(),
+                // TODO(PR-B2b): resolve via meta cache (currently placeholder)
+                asset: 0,
                 by_cloid: Some(c),
                 by_oid: None,
             }));

--- a/executor/crates/executor-core/src/intent.rs
+++ b/executor/crates/executor-core/src/intent.rs
@@ -73,6 +73,10 @@ impl AlgoParams {
 pub struct OrderIntent {
     pub cloid: Cloid,
     pub symbol: Symbol,
+    /// HL universe asset index (perp index, or 10000 + spot index). Required
+    /// at the wire layer; resolved from `symbol` via the meta cache at the
+    /// caller side (typically executor-server startup).
+    pub asset: u32,
     pub side: Side,
     pub px: Decimal,
     pub sz: Decimal,
@@ -84,6 +88,8 @@ pub struct OrderIntent {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CancelIntent {
     pub symbol: Symbol,
+    /// HL universe asset index. Same source as `OrderIntent.asset`.
+    pub asset: u32,
     /// Either oid (exchange-returned) or cloid (client-generated). cloid preferred.
     pub by_cloid: Option<Cloid>,
     pub by_oid: Option<OrderId>,

--- a/executor/crates/executor-hl/Cargo.toml
+++ b/executor/crates/executor-hl/Cargo.toml
@@ -49,6 +49,7 @@ hex = { workspace = true }
 
 [dev-dependencies]
 mockall = { workspace = true }
+mockito = { workspace = true }
 proptest = { workspace = true }
 rstest = { workspace = true }
 rust_decimal_macros = { workspace = true }

--- a/executor/crates/executor-hl/src/batch_sender.rs
+++ b/executor/crates/executor-hl/src/batch_sender.rs
@@ -241,6 +241,7 @@ mod tests {
         OrderIntent {
             cloid,
             symbol: Symbol::new("BTC"),
+            asset: 0,
             side: Side::Long,
             px: dec!(50000),
             sz: dec!(0.01),
@@ -286,6 +287,7 @@ mod tests {
         sender
             .enqueue(OrderOrCancel::Cancel(CancelIntent {
                 symbol: Symbol::new("BTC"),
+                asset: 0,
                 by_cloid: Some(Cloid::new()),
                 by_oid: None,
             }))

--- a/executor/crates/executor-hl/src/eip712.rs
+++ b/executor/crates/executor-hl/src/eip712.rs
@@ -79,6 +79,21 @@ pub struct ScheduleCancelAction {
     pub time: Option<u64>,
 }
 
+/// `{"type": "cancelByCloid", "cancels": [{asset, cloid}, ...]}`
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CancelByCloidAction {
+    #[serde(rename = "type")]
+    pub action_type: String,
+    pub cancels: Vec<CancelByCloidWire>,
+}
+
+/// One cancel wire item. Field order: asset (full word, NOT `a`), cloid.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CancelByCloidWire {
+    pub asset: u32,
+    pub cloid: String,
+}
+
 // === EIP-712 typed-data ===
 
 sol! {
@@ -210,5 +225,28 @@ mod tests {
         let t = build_agent(h, false);
         assert_eq!(m.source, "a");
         assert_eq!(t.source, "b");
+    }
+
+    /// `pack_action(&CancelByCloidAction{...})` must serialize as a msgpack
+    /// MAP (not array), with `type`/`cancels` keys at the top and per-cancel
+    /// `asset`/`cloid` keys nested. Sanity check only — full byte match isn't
+    /// required because the cross-check fixture covers signing end-to-end via
+    /// dispatch_and_hash.
+    #[test]
+    fn cancel_by_cloid_action_msgpack_starts_with_map_marker() {
+        let action = CancelByCloidAction {
+            action_type: "cancelByCloid".into(),
+            cancels: vec![CancelByCloidWire {
+                asset: 1,
+                cloid: "0x00000000000000000000000000000001".into(),
+            }],
+        };
+        let bytes = pack_action(&action).unwrap();
+        // 0x82 = fix-map(2) — top-level has "type" + "cancels"
+        assert_eq!(
+            bytes[0], 0x82,
+            "expected fix-map(2), got 0x{:02x}",
+            bytes[0]
+        );
     }
 }

--- a/executor/crates/executor-hl/src/eip712.rs
+++ b/executor/crates/executor-hl/src/eip712.rs
@@ -20,6 +20,9 @@ use alloy::primitives::{keccak256, Address, B256};
 use alloy::sol;
 use alloy::sol_types::{eip712_domain, Eip712Domain};
 
+use executor_core::intent::OrderIntent;
+use executor_core::types::{Side, Tif};
+
 /// Serialize an action struct to msgpack bytes in the named-map form Python
 /// SDK uses. Always call this — never `rmp_serde::to_vec` directly — for any
 /// payload that flows into `action_hash`.
@@ -92,6 +95,32 @@ pub struct CancelByCloidAction {
 pub struct CancelByCloidWire {
     pub asset: u32,
     pub cloid: String,
+}
+
+/// Convert an `OrderIntent` (executor-core domain type) into the HL wire
+/// shape `OrderWire`.
+///
+/// The caller passes `OrderIntent.asset` directly (set at intent construction
+/// time, currently 0 for algorithm-runtime callers — to be resolved via
+/// meta cache in PR-B2b).
+pub fn order_intent_to_wire(intent: &OrderIntent) -> OrderWire {
+    OrderWire {
+        a: intent.asset,
+        b: matches!(intent.side, Side::Long),
+        p: format!("{}", intent.px),
+        s: format!("{}", intent.sz),
+        r: intent.reduce_only,
+        t: OrderTypeWire {
+            limit: LimitTif {
+                tif: match intent.tif {
+                    Tif::Alo => "Alo".into(),
+                    Tif::Ioc => "Ioc".into(),
+                    Tif::Gtc => "Gtc".into(),
+                },
+            },
+        },
+        c: Some(format!("{}", intent.cloid)),
+    }
 }
 
 // === EIP-712 typed-data ===

--- a/executor/crates/executor-hl/src/hl_client.rs
+++ b/executor/crates/executor-hl/src/hl_client.rs
@@ -553,13 +553,55 @@ impl HlClient for RealHlClient {
 
     async fn cancel_orders(&self, cancels: &[CancelIntent]) -> Result<Vec<OrderResponse>, HlError> {
         if cancels.is_empty() {
-            return Ok(vec![]);
+            return Ok(Vec::new());
         }
-        let _wait = self.rate_limiter.acquire(cancels.len() as u32).await;
-        Err(HlError::Exchange {
-            code: Some("not_implemented".into()),
-            message: "RealHlClient::cancel_orders scaffold (see place_orders).".into(),
-        })
+
+        let weight = 1 + (cancels.len() as u32 / 40);
+        let _wait = self.rate_limiter.acquire(weight).await;
+
+        // by_cloid only. by_oid is explicitly rejected (PR-B2a scope).
+        let cancel_wires: Result<Vec<crate::eip712::CancelByCloidWire>, HlError> = cancels
+            .iter()
+            .map(|c| {
+                if c.by_oid.is_some() {
+                    return Err(HlError::ActionFormat(
+                        "by_oid cancel not supported in PR-B2a; use by_cloid".into(),
+                    ));
+                }
+                let cloid = c.by_cloid.ok_or_else(|| {
+                    HlError::ActionFormat("CancelIntent missing both by_cloid and by_oid".into())
+                })?;
+                Ok(crate::eip712::CancelByCloidWire {
+                    asset: c.asset,
+                    cloid: format!("{}", cloid),
+                })
+            })
+            .collect();
+        let cancel_wires = cancel_wires?;
+
+        let action = crate::eip712::CancelByCloidAction {
+            action_type: "cancelByCloid".into(),
+            cancels: cancel_wires,
+        };
+        let action_value = serde_json::to_value(&action)
+            .map_err(|e| HlError::ActionFormat(format!("cancel serialize: {e}")))?;
+
+        let nonce = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or_default();
+
+        let sig = self.signer.sign_l1(&action_value, nonce, None).await?;
+
+        let body = serde_json::json!({
+            "action": action,
+            "nonce": nonce,
+            "signature": sig,
+            "vaultAddress": serde_json::Value::Null,
+        });
+
+        let resp_text = self.post_exchange(&body).await?;
+        parse_cancel_response(&resp_text, cancels)
     }
 }
 
@@ -641,6 +683,70 @@ fn parse_exchange_response(
                 oid: None,
                 status: "unknown".into(),
                 error: Some(format!("unknown status shape: {status}")),
+            });
+        }
+    }
+    Ok(out)
+}
+
+/// Parse HL `/exchange` response for a cancelByCloid action.
+///
+/// HL returns cancel success as the bare string `"success"` (NOT an object,
+/// unlike order responses). Per-cancel error is `{"error": "<msg>"}`.
+fn parse_cancel_response(
+    text: &str,
+    cancels: &[CancelIntent],
+) -> Result<Vec<OrderResponse>, HlError> {
+    let v: serde_json::Value = serde_json::from_str(text)
+        .map_err(|e| HlError::InvalidResponse(format!("parse cancel json: {e}")))?;
+
+    if v.get("status").and_then(|s| s.as_str()) == Some("err") {
+        let msg = v
+            .get("response")
+            .and_then(|r| r.as_str())
+            .unwrap_or("(no msg)");
+        return Err(HlError::Exchange {
+            code: Some("top_level_err".into()),
+            message: msg.into(),
+        });
+    }
+
+    let statuses = v
+        .pointer("/response/data/statuses")
+        .and_then(|s| s.as_array())
+        .ok_or_else(|| HlError::InvalidResponse("cancel statuses missing".into()))?;
+
+    if statuses.len() != cancels.len() {
+        return Err(HlError::InvalidResponse(format!(
+            "cancel statuses len {} != cancels len {}",
+            statuses.len(),
+            cancels.len()
+        )));
+    }
+
+    let mut out = Vec::with_capacity(statuses.len());
+    for (status, intent) in statuses.iter().zip(cancels.iter()) {
+        let cloid = intent.by_cloid.unwrap_or_default();
+        if status.as_str() == Some("success") {
+            out.push(OrderResponse {
+                cloid,
+                oid: None,
+                status: "cancelled".into(),
+                error: None,
+            });
+        } else if let Some(err) = status.get("error") {
+            out.push(OrderResponse {
+                cloid,
+                oid: None,
+                status: "error".into(),
+                error: Some(err.as_str().unwrap_or("(no msg)").into()),
+            });
+        } else {
+            out.push(OrderResponse {
+                cloid,
+                oid: None,
+                status: "unknown".into(),
+                error: Some(format!("unknown cancel status shape: {status}")),
             });
         }
     }

--- a/executor/crates/executor-hl/src/hl_client.rs
+++ b/executor/crates/executor-hl/src/hl_client.rs
@@ -503,7 +503,7 @@ impl HlClient for RealHlClient {
             .map(|d| d.as_millis() as u64)
             .unwrap_or_default();
         let action = serde_json::json!({"type": "order", "orders": orders.len()});
-        let _sig = self.signer.sign_l1(&action, nonce).await?;
+        let _sig = self.signer.sign_l1(&action, nonce, None).await?;
 
         Err(HlError::Exchange {
             code: Some("not_implemented".into()),

--- a/executor/crates/executor-hl/src/hl_client.rs
+++ b/executor/crates/executor-hl/src/hl_client.rs
@@ -538,6 +538,7 @@ mod tests {
         let oi = OrderIntent {
             cloid: Cloid::new(),
             symbol: Symbol::new("BTC"),
+            asset: 0,
             side: Side::Long,
             px: dec!(50000),
             sz: dec!(0.1),
@@ -550,6 +551,7 @@ mod tests {
         assert_eq!(m.placed_calls().len(), 1);
         let ci = CancelIntent {
             symbol: Symbol::new("BTC"),
+            asset: 0,
             by_cloid: Some(oi.cloid),
             by_oid: None,
         };

--- a/executor/crates/executor-hl/src/hl_client.rs
+++ b/executor/crates/executor-hl/src/hl_client.rs
@@ -559,22 +559,22 @@ impl HlClient for RealHlClient {
         let weight = 1 + (cancels.len() as u32 / 40);
         let _wait = self.rate_limiter.acquire(weight).await;
 
-        // by_cloid only. by_oid is explicitly rejected (PR-B2a scope).
+        // PR-B2a: cancelByCloid only. If `by_cloid` is present we use it
+        // (silently ignoring any `by_oid` to avoid breaking emergency_stop
+        // flows that opportunistically include both). If only `by_oid` is
+        // present (no cloid), we reject — by-oid path arrives in a later PR.
         let cancel_wires: Result<Vec<crate::eip712::CancelByCloidWire>, HlError> = cancels
             .iter()
-            .map(|c| {
-                if c.by_oid.is_some() {
-                    return Err(HlError::ActionFormat(
-                        "by_oid cancel not supported in PR-B2a; use by_cloid".into(),
-                    ));
-                }
-                let cloid = c.by_cloid.ok_or_else(|| {
-                    HlError::ActionFormat("CancelIntent missing both by_cloid and by_oid".into())
-                })?;
-                Ok(crate::eip712::CancelByCloidWire {
+            .map(|c| match c.by_cloid {
+                Some(cloid) => Ok(crate::eip712::CancelByCloidWire {
                     asset: c.asset,
                     cloid: format!("{}", cloid),
-                })
+                }),
+                None => Err(HlError::ActionFormat(
+                    "by_oid-only cancel not supported in PR-B2a; CancelIntent must \
+                     include by_cloid (PR-B2b will add by_oid path)"
+                        .into(),
+                )),
             })
             .collect();
         let cancel_wires = cancel_wires?;
@@ -612,6 +612,17 @@ impl HlClient for RealHlClient {
 /// - `{"filled": {"oid": <u64>, "totalSz": "...", "avgPx": "..."}}` -> status="filled"
 /// - `{"error": "<msg>"}` -> status="error"
 ///
+/// Render a `serde_json::Value` as a human-readable error string.
+/// Strings are emitted verbatim; objects/arrays are rendered as compact JSON
+/// so the diagnostic detail is preserved instead of being collapsed to "(no msg)".
+fn json_to_err_string(v: &serde_json::Value) -> String {
+    if let Some(s) = v.as_str() {
+        s.to_string()
+    } else {
+        v.to_string()
+    }
+}
+
 /// Top-level `{"status":"err", "response": "<msg>"}` returns `Err(HlError::Exchange)`.
 fn parse_exchange_response(
     text: &str,
@@ -623,11 +634,11 @@ fn parse_exchange_response(
     if v.get("status").and_then(|s| s.as_str()) == Some("err") {
         let msg = v
             .get("response")
-            .and_then(|r| r.as_str())
-            .unwrap_or("(no msg)");
+            .map(json_to_err_string)
+            .unwrap_or_else(|| "(no msg)".into());
         return Err(HlError::Exchange {
             code: Some("top_level_err".into()),
-            message: msg.into(),
+            message: msg,
         });
     }
 
@@ -670,12 +681,11 @@ fn parse_exchange_response(
                 error: None,
             });
         } else if let Some(err) = status.get("error") {
-            let msg = err.as_str().unwrap_or("(no msg)");
             out.push(OrderResponse {
                 cloid,
                 oid: None,
                 status: "error".into(),
-                error: Some(msg.into()),
+                error: Some(json_to_err_string(err)),
             });
         } else {
             out.push(OrderResponse {
@@ -703,11 +713,11 @@ fn parse_cancel_response(
     if v.get("status").and_then(|s| s.as_str()) == Some("err") {
         let msg = v
             .get("response")
-            .and_then(|r| r.as_str())
-            .unwrap_or("(no msg)");
+            .map(json_to_err_string)
+            .unwrap_or_else(|| "(no msg)".into());
         return Err(HlError::Exchange {
             code: Some("top_level_err".into()),
-            message: msg.into(),
+            message: msg,
         });
     }
 
@@ -739,7 +749,7 @@ fn parse_cancel_response(
                 cloid,
                 oid: None,
                 status: "error".into(),
-                error: Some(err.as_str().unwrap_or("(no msg)").into()),
+                error: Some(json_to_err_string(err)),
             });
         } else {
             out.push(OrderResponse {

--- a/executor/crates/executor-hl/src/hl_client.rs
+++ b/executor/crates/executor-hl/src/hl_client.rs
@@ -414,6 +414,27 @@ impl RealHlClient {
         }
         Ok(text)
     }
+
+    /// POST a JSON body to the /exchange endpoint and return the response body.
+    /// Mirrors `post_info` but targets `config.exchange_url`.
+    async fn post_exchange(&self, body: &serde_json::Value) -> Result<String, HlError> {
+        let resp = self
+            .http
+            .post(&self.config.exchange_url)
+            .json(body)
+            .send()
+            .await
+            .map_err(|e| HlError::Network(e.to_string()))?;
+        let status = resp.status();
+        let text = resp
+            .text()
+            .await
+            .map_err(|e| HlError::Network(e.to_string()))?;
+        if !status.is_success() {
+            return Err(HlError::Network(format!("HTTP {status}: {text}")));
+        }
+        Ok(text)
+    }
 }
 
 #[async_trait]
@@ -491,26 +512,43 @@ impl HlClient for RealHlClient {
     }
 
     async fn place_orders(&self, orders: &[OrderIntent]) -> Result<Vec<OrderResponse>, HlError> {
-        // 80% プロト: signer + rate_limiter の枠だけ通す. 実 POST は鍵管理ブレスト後.
         if orders.is_empty() {
-            return Ok(vec![]);
+            return Ok(Vec::new());
         }
-        let _wait = self.rate_limiter.acquire(orders.len() as u32).await;
 
-        // sign for nonce visibility (no real submission).
+        let weight = 1 + (orders.len() as u32 / 40);
+        let _wait = self.rate_limiter.acquire(weight).await;
+
+        let order_wires: Vec<crate::eip712::OrderWire> = orders
+            .iter()
+            .map(crate::eip712::order_intent_to_wire)
+            .collect();
+
+        let action = crate::eip712::OrderAction {
+            action_type: "order".into(),
+            orders: order_wires,
+            grouping: "na".into(),
+        };
+        let action_value = serde_json::to_value(&action)
+            .map_err(|e| HlError::ActionFormat(format!("order serialize: {e}")))?;
+
         let nonce = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map(|d| d.as_millis() as u64)
             .unwrap_or_default();
-        let action = serde_json::json!({"type": "order", "orders": orders.len()});
-        let _sig = self.signer.sign_l1(&action, nonce, None).await?;
 
-        Err(HlError::Exchange {
-            code: Some("not_implemented".into()),
-            message: "RealHlClient::place_orders is the 80% scaffold; \
-                      full HL signing arrives with the key-management PR"
-                .into(),
-        })
+        // PR-B2a: vault always None. PR-B2b will plumb vault through `place_orders`.
+        let sig = self.signer.sign_l1(&action_value, nonce, None).await?;
+
+        let body = serde_json::json!({
+            "action": action,
+            "nonce": nonce,
+            "signature": sig,
+            "vaultAddress": serde_json::Value::Null,
+        });
+
+        let resp_text = self.post_exchange(&body).await?;
+        parse_exchange_response(&resp_text, orders)
     }
 
     async fn cancel_orders(&self, cancels: &[CancelIntent]) -> Result<Vec<OrderResponse>, HlError> {
@@ -523,6 +561,90 @@ impl HlClient for RealHlClient {
             message: "RealHlClient::cancel_orders scaffold (see place_orders).".into(),
         })
     }
+}
+
+/// Parse HL `/exchange` response for an order action into per-order `OrderResponse`.
+///
+/// Recognized status shapes per element of `response.data.statuses`:
+/// - `{"resting": {"oid": <u64>}}` -> status="resting"
+/// - `{"filled": {"oid": <u64>, "totalSz": "...", "avgPx": "..."}}` -> status="filled"
+/// - `{"error": "<msg>"}` -> status="error"
+///
+/// Top-level `{"status":"err", "response": "<msg>"}` returns `Err(HlError::Exchange)`.
+fn parse_exchange_response(
+    text: &str,
+    orders: &[OrderIntent],
+) -> Result<Vec<OrderResponse>, HlError> {
+    let v: serde_json::Value = serde_json::from_str(text)
+        .map_err(|e| HlError::InvalidResponse(format!("parse exchange json: {e}")))?;
+
+    if v.get("status").and_then(|s| s.as_str()) == Some("err") {
+        let msg = v
+            .get("response")
+            .and_then(|r| r.as_str())
+            .unwrap_or("(no msg)");
+        return Err(HlError::Exchange {
+            code: Some("top_level_err".into()),
+            message: msg.into(),
+        });
+    }
+
+    let statuses = v
+        .pointer("/response/data/statuses")
+        .and_then(|s| s.as_array())
+        .ok_or_else(|| HlError::InvalidResponse("statuses missing".into()))?;
+
+    if statuses.len() != orders.len() {
+        return Err(HlError::InvalidResponse(format!(
+            "statuses len {} != orders len {}",
+            statuses.len(),
+            orders.len()
+        )));
+    }
+
+    let mut out = Vec::with_capacity(statuses.len());
+    for (status, intent) in statuses.iter().zip(orders.iter()) {
+        let cloid = intent.cloid;
+        if let Some(resting) = status.get("resting") {
+            let oid = resting
+                .get("oid")
+                .and_then(|o| o.as_u64())
+                .ok_or_else(|| HlError::InvalidResponse("resting.oid missing".into()))?;
+            out.push(OrderResponse {
+                cloid,
+                oid: Some(OrderId(oid)),
+                status: "resting".into(),
+                error: None,
+            });
+        } else if let Some(filled) = status.get("filled") {
+            let oid = filled
+                .get("oid")
+                .and_then(|o| o.as_u64())
+                .ok_or_else(|| HlError::InvalidResponse("filled.oid missing".into()))?;
+            out.push(OrderResponse {
+                cloid,
+                oid: Some(OrderId(oid)),
+                status: "filled".into(),
+                error: None,
+            });
+        } else if let Some(err) = status.get("error") {
+            let msg = err.as_str().unwrap_or("(no msg)");
+            out.push(OrderResponse {
+                cloid,
+                oid: None,
+                status: "error".into(),
+                error: Some(msg.into()),
+            });
+        } else {
+            out.push(OrderResponse {
+                cloid,
+                oid: None,
+                status: "unknown".into(),
+                error: Some(format!("unknown status shape: {status}")),
+            });
+        }
+    }
+    Ok(out)
 }
 
 #[cfg(test)]

--- a/executor/crates/executor-hl/src/signer.rs
+++ b/executor/crates/executor-hl/src/signer.rs
@@ -32,8 +32,15 @@ pub trait Signer: Send + Sync {
     /// Address that this signer signs for.
     fn address(&self) -> Address;
 
-    /// Sign an L1 action with a specific nonce. Returns EIP-712 signature.
-    async fn sign_l1(&self, action: &Action, nonce: u64) -> Result<Signature, HlError>;
+    /// Sign an L1 action with a specific nonce.
+    /// `vault` allows trading on behalf of a vault/subaccount; pass `None`
+    /// for direct master/agent action.
+    async fn sign_l1(
+        &self,
+        action: &Action,
+        nonce: u64,
+        vault: Option<&Address>,
+    ) -> Result<Signature, HlError>;
 }
 
 /// 80 % prototype signer. Always returns a deterministic dummy signature so the
@@ -71,7 +78,12 @@ impl Signer for MockSigner {
         self.address.clone()
     }
 
-    async fn sign_l1(&self, _action: &Action, nonce: u64) -> Result<Signature, HlError> {
+    async fn sign_l1(
+        &self,
+        _action: &Action,
+        nonce: u64,
+        _vault: Option<&Address>,
+    ) -> Result<Signature, HlError> {
         // Deterministic dummy: r/s embed the nonce so the test can assert on them.
         Ok(Signature {
             r: format!("0x{:064x}", nonce),
@@ -110,8 +122,24 @@ impl Signer for Eip712AgentSigner {
         Address::new(format!("{:#x}", self.inner.address()))
     }
 
-    async fn sign_l1(&self, action: &Action, nonce: u64) -> Result<Signature, HlError> {
-        let hash = dispatch_and_hash(action, nonce, None)?;
+    async fn sign_l1(
+        &self,
+        action: &Action,
+        nonce: u64,
+        vault: Option<&Address>,
+    ) -> Result<Signature, HlError> {
+        // Convert executor_core::types::Address (String wrapper) to alloy
+        // 20-byte typed Address for action_hash. Parse failures surface as
+        // ActionFormat (dynamic input data, not config).
+        let vault_alloy = vault
+            .map(|a| {
+                a.as_str()
+                    .parse::<AlloyAddress>()
+                    .map_err(|e| HlError::ActionFormat(format!("vault address parse: {e}")))
+            })
+            .transpose()?;
+
+        let hash = dispatch_and_hash(action, nonce, vault_alloy.as_ref())?;
         let agent = build_agent(hash, self.is_mainnet);
         let signing_hash = agent.eip712_signing_hash(&l1_domain());
 
@@ -194,8 +222,8 @@ mod tests {
     #[tokio::test]
     async fn mock_signer_sign_is_deterministic_per_nonce() {
         let s = MockSigner::new();
-        let a = s.sign_l1(&json!({"x": 1}), 12345).await.unwrap();
-        let b = s.sign_l1(&json!({"y": 2}), 12345).await.unwrap();
+        let a = s.sign_l1(&json!({"x": 1}), 12345, None).await.unwrap();
+        let b = s.sign_l1(&json!({"y": 2}), 12345, None).await.unwrap();
         // Mock includes the nonce in the signature, so same nonce → same r/s.
         assert_eq!(a, b);
     }
@@ -203,8 +231,8 @@ mod tests {
     #[tokio::test]
     async fn mock_signer_different_nonce_different_sig() {
         let s = MockSigner::new();
-        let a = s.sign_l1(&json!({}), 1).await.unwrap();
-        let b = s.sign_l1(&json!({}), 2).await.unwrap();
+        let a = s.sign_l1(&json!({}), 1, None).await.unwrap();
+        let b = s.sign_l1(&json!({}), 2, None).await.unwrap();
         assert_ne!(a, b);
     }
 }

--- a/executor/crates/executor-hl/src/signer.rs
+++ b/executor/crates/executor-hl/src/signer.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use crate::errors::HlError;
 
 use crate::eip712::{action_hash, build_agent, l1_domain};
-use crate::eip712::{DummyAction, OrderAction, ScheduleCancelAction};
+use crate::eip712::{CancelByCloidAction, DummyAction, OrderAction, ScheduleCancelAction};
 use alloy::primitives::Address as AlloyAddress;
 use alloy::signers::SignerSync;
 use alloy::sol_types::SolStruct;
@@ -200,6 +200,12 @@ fn dispatch_and_hash(
                 .map_err(|e| HlError::ActionFormat(format!("scheduleCancel decode: {e}")))?;
             action_hash(&typed, nonce, vault, None)
                 .map_err(|e| HlError::ActionFormat(format!("scheduleCancel msgpack: {e}")))
+        }
+        "cancelByCloid" => {
+            let typed = CancelByCloidAction::deserialize(action)
+                .map_err(|e| HlError::ActionFormat(format!("cancelByCloid decode: {e}")))?;
+            action_hash(&typed, nonce, vault, None)
+                .map_err(|e| HlError::ActionFormat(format!("cancelByCloid msgpack: {e}")))
         }
         other => Err(HlError::ActionFormat(format!(
             "unsupported action type for Eip712AgentSigner: {other}"

--- a/executor/crates/executor-hl/src/ws_state.rs
+++ b/executor/crates/executor-hl/src/ws_state.rs
@@ -222,6 +222,7 @@ mod tests {
         OrderIntent {
             cloid,
             symbol: Symbol::new("BTC"),
+            asset: 0,
             side: Side::Long,
             px: dec!(100),
             sz: dec!(1),

--- a/executor/crates/executor-hl/tests/place_cancel_mock.rs
+++ b/executor/crates/executor-hl/tests/place_cancel_mock.rs
@@ -178,7 +178,7 @@ async fn cancel_orders_success_string_response() {
 }
 
 #[tokio::test]
-async fn cancel_orders_by_oid_returns_action_format_error() {
+async fn cancel_orders_by_oid_only_returns_action_format_error() {
     let server = mockito::Server::new_async().await;
     // No mock needed — the error fires before any HTTP call.
     let client = make_client(&server.url());
@@ -192,10 +192,41 @@ async fn cancel_orders_by_oid_returns_action_format_error() {
     match err {
         HlError::ActionFormat(msg) => {
             assert!(
-                msg.contains("by_oid cancel not supported"),
+                msg.contains("by_oid-only cancel not supported"),
                 "msg was: {msg}"
             );
         }
         other => panic!("expected ActionFormat err, got {other:?}"),
     }
+}
+
+#[tokio::test]
+async fn cancel_orders_by_cloid_with_oid_present_uses_cloid_path() {
+    // Gemini PR-B2a review fix: emergency_stop in routes.rs sets BOTH by_cloid
+    // and by_oid. Earlier impl rejected the whole batch on `by_oid.is_some()`.
+    // After fix, we silently use by_cloid and ignore by_oid for cancel-by-cloid path.
+    let mut server = mockito::Server::new_async().await;
+    let _m = server
+        .mock("POST", "/exchange")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"status":"ok","response":{"type":"cancel","data":{"statuses":["success"]}}}"#,
+        )
+        .create_async()
+        .await;
+
+    let client = make_client(&server.url());
+    let cloid = Cloid::new();
+    let cancel = CancelIntent {
+        symbol: Symbol::new("ETH"),
+        asset: 1,
+        by_cloid: Some(cloid),
+        by_oid: Some(OrderId(99999)), // present alongside cloid; should be ignored
+    };
+    let resp = client.cancel_orders(&[cancel]).await.unwrap();
+    assert_eq!(resp.len(), 1);
+    assert_eq!(resp[0].status, "cancelled");
+    assert_eq!(resp[0].cloid, cloid);
+    assert!(resp[0].error.is_none());
 }

--- a/executor/crates/executor-hl/tests/place_cancel_mock.rs
+++ b/executor/crates/executor-hl/tests/place_cancel_mock.rs
@@ -1,0 +1,201 @@
+//! Mock-backend integration tests for RealHlClient::place_orders/cancel_orders.
+//!
+//! Uses mockito to mock HL /exchange responses. No real network, no PK
+//! beyond the well-known test PK from PR-B1's signing fixture. Real
+//! testnet smoke is in PR-B2b.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use executor_core::cloid::Cloid;
+use executor_core::intent::{CancelIntent, OrderIntent};
+use executor_core::symbol::Symbol;
+use executor_core::types::{OrderId, Side, Tif};
+use executor_hl::errors::HlError;
+use executor_hl::hl_client::{HlClient, HlConfig, RealHlClient};
+use executor_hl::signer::Eip712AgentSigner;
+use rust_decimal_macros::dec;
+use secrecy::SecretString;
+use std::sync::Arc;
+
+const TEST_PK: &str = "0x0123456789012345678901234567890123456789012345678901234567890123";
+
+fn make_client(server_url: &str) -> RealHlClient {
+    let signer =
+        Arc::new(Eip712AgentSigner::from_secret(SecretString::new(TEST_PK.into()), false).unwrap());
+    let config = HlConfig {
+        info_url: format!("{server_url}/info"),
+        exchange_url: format!("{server_url}/exchange"),
+        ws_url: "ws://unused".into(),
+    };
+    RealHlClient::new(config, signer)
+}
+
+fn make_order_intent() -> OrderIntent {
+    OrderIntent {
+        cloid: Cloid::new(),
+        symbol: Symbol::new("ETH"),
+        asset: 1,
+        side: Side::Long,
+        px: dec!(2000),
+        sz: dec!(0.001),
+        tif: Tif::Alo,
+        reduce_only: false,
+    }
+}
+
+fn make_cancel_intent(cloid: Cloid) -> CancelIntent {
+    CancelIntent {
+        symbol: Symbol::new("ETH"),
+        asset: 1,
+        by_cloid: Some(cloid),
+        by_oid: None,
+    }
+}
+
+#[tokio::test]
+async fn place_orders_resting_response_parses_to_oid() {
+    let mut server = mockito::Server::new_async().await;
+    let _m = server
+        .mock("POST", "/exchange")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"status":"ok","response":{"type":"order","data":{"statuses":[{"resting":{"oid":12345}}]}}}"#,
+        )
+        .create_async()
+        .await;
+
+    let client = make_client(&server.url());
+    let resp = client.place_orders(&[make_order_intent()]).await.unwrap();
+    assert_eq!(resp.len(), 1);
+    assert_eq!(resp[0].status, "resting");
+    assert_eq!(resp[0].oid, Some(OrderId(12345)));
+    assert!(resp[0].error.is_none());
+}
+
+#[tokio::test]
+async fn place_orders_filled_response_parses_to_oid_and_filled_status() {
+    let mut server = mockito::Server::new_async().await;
+    let _m = server
+        .mock("POST", "/exchange")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"status":"ok","response":{"type":"order","data":{"statuses":[{"filled":{"oid":67890,"totalSz":"0.001","avgPx":"2000.0"}}]}}}"#,
+        )
+        .create_async()
+        .await;
+
+    let client = make_client(&server.url());
+    let resp = client.place_orders(&[make_order_intent()]).await.unwrap();
+    assert_eq!(resp.len(), 1);
+    assert_eq!(resp[0].status, "filled");
+    assert_eq!(resp[0].oid, Some(OrderId(67890)));
+    assert!(resp[0].error.is_none());
+}
+
+#[tokio::test]
+async fn place_orders_per_order_error_keeps_cloid_and_attaches_error() {
+    let mut server = mockito::Server::new_async().await;
+    let _m = server
+        .mock("POST", "/exchange")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"status":"ok","response":{"type":"order","data":{"statuses":[{"error":"MinTradeNtl"}]}}}"#,
+        )
+        .create_async()
+        .await;
+
+    let client = make_client(&server.url());
+    let intent = make_order_intent();
+    let cloid = intent.cloid;
+    let resp = client.place_orders(&[intent]).await.unwrap();
+    assert_eq!(resp.len(), 1);
+    assert_eq!(resp[0].status, "error");
+    assert_eq!(resp[0].cloid, cloid);
+    assert!(resp[0].error.as_deref() == Some("MinTradeNtl"));
+}
+
+#[tokio::test]
+async fn place_orders_top_level_err_returns_hl_error_exchange() {
+    let mut server = mockito::Server::new_async().await;
+    let _m = server
+        .mock("POST", "/exchange")
+        .with_status(200)
+        .with_body(r#"{"status":"err","response":"Insufficient margin"}"#)
+        .create_async()
+        .await;
+
+    let client = make_client(&server.url());
+    let err = client
+        .place_orders(&[make_order_intent()])
+        .await
+        .unwrap_err();
+    match err {
+        HlError::Exchange { code, message } => {
+            assert_eq!(code.as_deref(), Some("top_level_err"));
+            assert!(
+                message.contains("Insufficient margin"),
+                "message was: {message}"
+            );
+        }
+        other => panic!("expected Exchange err, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn place_orders_empty_returns_empty() {
+    let server = mockito::Server::new_async().await;
+    let client = make_client(&server.url());
+    let resp = client.place_orders(&[]).await.unwrap();
+    assert!(resp.is_empty());
+}
+
+#[tokio::test]
+async fn cancel_orders_success_string_response() {
+    let mut server = mockito::Server::new_async().await;
+    let _m = server
+        .mock("POST", "/exchange")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"status":"ok","response":{"type":"cancel","data":{"statuses":["success"]}}}"#,
+        )
+        .create_async()
+        .await;
+
+    let client = make_client(&server.url());
+    let cloid = Cloid::new();
+    let resp = client
+        .cancel_orders(&[make_cancel_intent(cloid)])
+        .await
+        .unwrap();
+    assert_eq!(resp.len(), 1);
+    assert_eq!(resp[0].status, "cancelled");
+    assert_eq!(resp[0].cloid, cloid);
+    assert!(resp[0].error.is_none());
+}
+
+#[tokio::test]
+async fn cancel_orders_by_oid_returns_action_format_error() {
+    let server = mockito::Server::new_async().await;
+    // No mock needed — the error fires before any HTTP call.
+    let client = make_client(&server.url());
+    let cancel = CancelIntent {
+        symbol: Symbol::new("ETH"),
+        asset: 1,
+        by_cloid: None,
+        by_oid: Some(OrderId(99999)),
+    };
+    let err = client.cancel_orders(&[cancel]).await.unwrap_err();
+    match err {
+        HlError::ActionFormat(msg) => {
+            assert!(
+                msg.contains("by_oid cancel not supported"),
+                "msg was: {msg}"
+            );
+        }
+        other => panic!("expected ActionFormat err, got {other:?}"),
+    }
+}

--- a/executor/crates/executor-hl/tests/signing_cross_check.rs
+++ b/executor/crates/executor-hl/tests/signing_cross_check.rs
@@ -5,6 +5,7 @@
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
+use executor_core::types::Address as CoreAddress;
 use executor_hl::signer::{Eip712AgentSigner, Signer};
 use secrecy::SecretString;
 use serde::Deserialize;
@@ -29,7 +30,6 @@ struct Vector {
     name: String,
     action: serde_json::Value,
     nonce: u64,
-    #[allow(dead_code)] // PR-B1 dispatch_and_hash hard-codes vault=None
     vault_address: Option<String>,
     #[allow(dead_code)] // expires_after not yet exercised
     expires_after: Option<u64>,
@@ -77,15 +77,9 @@ async fn signer_address_matches_test_pk() {
 #[tokio::test]
 async fn cross_check_all_known_vectors() {
     let mut failed: Vec<String> = Vec::new();
-    let mut skipped: Vec<String> = Vec::new();
     for v in vectors() {
-        // PR-B1 dispatch_and_hash hard-codes vault=None; vault-bearing
-        // vectors must wait for PR-B2 to add the vault parameter.
-        if v.vault_address.is_some() {
-            skipped.push(v.name.clone());
-            eprintln!("SKIP (vault not yet supported): {}", v.name);
-            continue;
-        }
+        // Parse vault if present (executor_core::types::Address is a String wrapper).
+        let vault: Option<CoreAddress> = v.vault_address.as_deref().map(CoreAddress::new);
 
         let signer =
             Eip712AgentSigner::from_secret(SecretString::new(TEST_PK.into()), v.is_mainnet)
@@ -99,7 +93,7 @@ async fn cross_check_all_known_vectors() {
             v.name
         );
 
-        let sig = match signer.sign_l1(&v.action, v.nonce).await {
+        let sig = match signer.sign_l1(&v.action, v.nonce, vault.as_ref()).await {
             Ok(s) => s,
             Err(e) => {
                 failed.push(format!("{}: sign_l1 errored: {e}", v.name));
@@ -131,11 +125,7 @@ async fn cross_check_all_known_vectors() {
         }
     }
     eprintln!("\n=== cross-check summary ===");
-    eprintln!(
-        "vectors checked: {} (skipped: {:?})",
-        10 - skipped.len(),
-        skipped
-    );
+    eprintln!("vectors checked: 10 (all)");
     if !failed.is_empty() {
         panic!("\ncross-check failures:\n{}\n", failed.join("\n\n"));
     }

--- a/executor/crates/executor-server/src/routes.rs
+++ b/executor/crates/executor-server/src/routes.rs
@@ -262,6 +262,8 @@ pub async fn emergency_stop(
     for order in open_orders {
         let intent = CancelIntent {
             symbol: order.symbol.clone(),
+            // TODO(PR-B2b): resolve via meta cache (currently placeholder)
+            asset: 0,
             by_cloid: Some(order.cloid),
             by_oid: order.oid,
         };


### PR DESCRIPTION
## Summary

Stage B step 2a (PR-B2a) of the C-1 段階的検証 spec. Real `/exchange` POST happens here for the first time, but verification is mock-only — actual testnet smoke lands in PR-B2b.

- `Signer::sign_l1` gains `vault: Option<&Address>`. `MockSigner` ignores it; `Eip712AgentSigner` parses to alloy 20-byte Address and threads through `dispatch_and_hash` → `action_hash`.
- 2 vault-bearing cross-check vectors (`dummy_with_vault_{mainnet,testnet}`) now activated → **10/10 byte-identical** to HL python-sdk.
- `eip712`: new `CancelByCloidAction` / `CancelByCloidWire` structs (note: cancel uses `asset` full word, NOT `a` shorthand). New `order_intent_to_wire` helper.
- `RealHlClient`: real `place_orders` / `cancel_orders` implementations. New private `post_exchange` helper. New free functions `parse_exchange_response` (resting/filled/error/top-err) and `parse_cancel_response` (`"success"` string + per-cancel error).
- `OrderIntent` / `CancelIntent` get `asset: u32` field (required for wire layer). 21 algorithm-runtime + executor-server callers updated with `asset: 0` placeholder + `// TODO(PR-B2b)` comment pending meta-cache resolution.
- 8 mockito tests cover: place resting/filled/error/top-err/empty + cancel success/by_oid_only_reject/by_cloid_with_oid_present_uses_cloid (last test was added during Gemini review fix).

## Test plan

- [x] `cd executor && cargo test --workspace` — 142 tests pass (was 133)
- [x] `cd executor && cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cd executor && cargo fmt --all -- --check` — clean
- [x] `bash scripts/check_ci_local.sh` — green
- [x] Cross-check: 10/10 vectors r/s/v match python-sdk byte-identically

## Gemini deep review

Run \`gemini-review.sh deep\`. Result:
- **MUST-FIX 1 (fixed)**: original \`cancel_orders\` rejected any batch with \`by_oid\`. But \`executor-server::routes::emergency_stop\` sets BOTH \`by_cloid\` AND \`by_oid\`. Fixed: use \`by_cloid\` if present (ignoring \`by_oid\`), reject only when \`by_cloid\` is None and only \`by_oid\` is set.
- **SHOULD-FIX 1 (deferred to PR-B2b)**: \`OrderIntent.asset = 0\` placeholder for algorithm-runtime callers — must be replaced with actual symbol→index lookup before testnet investment, or all orders go to \`asset: 0\` (= BTC) by mistake.
- **SUGGESTION 1 (fixed)**: \`err.as_str().unwrap_or("(no msg)")\` would swallow JSON object error details. Introduced \`json_to_err_string\` helper for safe rendering.
- **SUGGESTION 2 (deferred)**: \`parse_cancel_response\` signature decoupling — non-trivial refactor.

## Notes

- \`cancelByCloid\` only. \`CancelIntent\` lacking \`by_cloid\` returns \`HlError::ActionFormat\` immediately (no HTTP call). by-oid-only cancel arrives in a later PR.
- mockito tests do NOT assert request body in detail (nonce is time-based, signature varies). Coverage is on response parsing.
- \`vault: None\` is hardcoded in \`place_orders\` / \`cancel_orders\` for PR-B2a. PR-B2b will plumb vault through these methods if subaccount support is needed.
- \`r/s\` are still always 64-hex padded (no leading-zero strip). Real HL acceptance verified in PR-B2b testnet smoke.

## Deferred (tracked for PR-B2b / later)

- Plumb \`vault: Option<&Address>\` parameter through \`place_orders\` / \`cancel_orders\` themselves (currently only on Signer trait).
- Resolve \`OrderIntent.asset\` via \`fetch_meta\` cache at executor-server startup; remove \`asset: 0\` placeholders from algo crate.
- testnet smoke (real \`/exchange\` POST) and r/s padding acceptance check.
- by-oid-only cancel path (for cases where cloid is unknown).

🤖 Generated with [Claude Code](https://claude.com/claude-code)