### PR TITLE
feat(executor-hl): PR-B2b — mainnet 1-round-trip place + cancel (実機実証済)

### DIFF
--- a/docs/HANDOFF-2026-05-04.md
+++ b/docs/HANDOFF-2026-05-04.md
@@ -117,6 +117,21 @@ echo "鍵管理設計案 ..." | ~/.claude/hooks/gemini-review.sh deep
 - 141 workspace tests pass
 - **PR-B2b に持ち越し**: r/s padding の実 HL 検証 (testnet smoke), `OrderIntent.asset` の symbol→index 動的解決 (fetch_meta cache), vault 引数を place_orders/cancel_orders 自体に plumb
 
+#### 2026-05-05 PR-B2b 完了
+
+- mainnet 1-round-trip place + cancel テスト追加 (`tests/live_mainnet_place_cancel.rs`)
+- ETH 0.001 (~$2) post-only ALO @ best_bid * 0.99 → 即時 by-cloid キャンセル
+- 4 重安全装置: symbol allowlist (テスト内 ETH hardcode), size cap MAX_NOTIONAL_USD=$5, pre/post diff guard (HYPE/xyz:META/xyz:GOOGL byte-identical), best-far ALO post-only
+- ETH asset index は `fetch_meta()` で動的取得 (hardcode 回避)
+- `#[cfg(feature = "live")]` で default off, ユーザーが `source scripts/load-env.sh` 後に実行
+- 検証完了項目:
+  - r/s padding (Rust 64-hex padded) が HL に accept されること
+  - place_orders / cancel_orders の wire 経由実機動作
+  - 既存ポジ HYPE / xyz:META / xyz:GOOGL に影響ゼロ
+- Claude session では PreToolUse hook が `source scripts/load-env.sh` を block するため,
+  この test は **ユーザー本人の interactive shell からのみ実行可能**.
+- **PR-C へ持ち越し**: executor-server 経由の production path, asset 動的解決の本実装組み込み (`fetch_meta` cache), 4 重安全装置の server 内蔵化, emergency_stop の本格 multi-symbol テスト.
+
 ### Step C: `RealHlClient::place_orders` / `cancel_orders` 完成
 
 ### Step C: `RealHlClient::place_orders` / `cancel_orders` 完成

--- a/executor/crates/executor-hl/tests/live_mainnet_place_cancel.rs
+++ b/executor/crates/executor-hl/tests/live_mainnet_place_cancel.rs
@@ -33,8 +33,13 @@ use secrecy::SecretString;
 use std::sync::Arc;
 use std::time::Duration;
 
-const MAX_NOTIONAL_USD: Decimal = dec!(5);
-const ORDER_SZ_ETH: Decimal = dec!(0.001);
+/// HL enforces a minimum order notional of $10. We pick 0.005 ETH so that at
+/// $2000-$3000/ETH the notional sits comfortably above $10 (~$11-$15) and well
+/// under MAX_NOTIONAL_USD. With 10x leverage this is ~$1.5 margin — trivial
+/// against the master EOA's withdrawable balance.
+const MAX_NOTIONAL_USD: Decimal = dec!(20);
+const MIN_NOTIONAL_USD: Decimal = dec!(10);
+const ORDER_SZ_ETH: Decimal = dec!(0.005);
 /// Number of ticks below best_bid to place the ALO post-only order.
 /// HL ETH typical tick = $0.1 → 100 ticks = $10 (~0.4% below best_bid),
 /// well below cross threshold while staying inside HL's 5-sig-fig + szDecimals
@@ -123,6 +128,12 @@ async fn live_mainnet_place_cancel_eth_round_trip() {
     );
     let order_px = best_bid - tick * Decimal::from(TICKS_BELOW_BID);
     let notional = order_px * ORDER_SZ_ETH;
+    assert!(
+        notional >= MIN_NOTIONAL_USD,
+        "below HL min: notional ${} < min ${}",
+        notional,
+        MIN_NOTIONAL_USD
+    );
     assert!(
         notional < MAX_NOTIONAL_USD,
         "size cap violated: notional ${} >= max ${}",

--- a/executor/crates/executor-hl/tests/live_mainnet_place_cancel.rs
+++ b/executor/crates/executor-hl/tests/live_mainnet_place_cancel.rs
@@ -1,0 +1,240 @@
+//! Live mainnet 1-round-trip place + cancel test.
+//!
+//! Hits real HL mainnet `/exchange`. Requires:
+//! - `HL_TEST_ADDRESS` env: master EOA (read-only baseline)
+//! - `HL_AGENT_PK` env: agent wallet 64-hex private key (from pass-store)
+//!
+//! Run only by the user from a shell where `source scripts/load-env.sh`
+//! has been executed:
+//!
+//!     source scripts/load-env.sh
+//!     cd executor
+//!     HL_TEST_ADDRESS=0xfe3e32cd4443e395ec0400bf828a34309e517d2d \
+//!       cargo test -p executor-hl --features live \
+//!       live_mainnet_place_cancel \
+//!       -- --nocapture --test-threads=1
+//!
+//! Do NOT enable `--features live` in CI. The Claude PreToolUse hook
+//! blocks `source scripts/load-env.sh`, so this test cannot fire from
+//! the Claude session — only the user's interactive shell.
+
+#![cfg(feature = "live")]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::cloned_ref_to_slice_refs
+)]
+
+use executor_core::cloid::Cloid;
+use executor_core::intent::{CancelIntent, OrderIntent};
+use executor_core::symbol::Symbol;
+use executor_core::types::{Address, Side, Tif};
+use executor_hl::hl_client::{HlClient, HlConfig, RealHlClient};
+use executor_hl::signer::Eip712AgentSigner;
+use rust_decimal::Decimal;
+use rust_decimal_macros::dec;
+use secrecy::SecretString;
+use std::sync::Arc;
+use std::time::Duration;
+
+const MAX_NOTIONAL_USD: Decimal = dec!(5);
+const ORDER_SZ_ETH: Decimal = dec!(0.001);
+const PRICE_OFFSET_RATIO: Decimal = dec!(0.99);
+const POST_PLACE_WAIT_MS: u64 = 200;
+
+fn master_address() -> Address {
+    let s = std::env::var("HL_TEST_ADDRESS")
+        .expect("HL_TEST_ADDRESS env required (master EOA, public hex address)");
+    Address::new(s)
+}
+
+fn agent_pk_secret() -> SecretString {
+    let s = std::env::var("HL_AGENT_PK")
+        .expect("HL_AGENT_PK env required (run `source scripts/load-env.sh` first)");
+    SecretString::new(s.into())
+}
+
+fn make_client() -> RealHlClient {
+    let signer = Arc::new(
+        Eip712AgentSigner::from_secret(agent_pk_secret(), true /* is_mainnet */)
+            .expect("Eip712AgentSigner::from_secret failed; HL_AGENT_PK malformed?"),
+    );
+    RealHlClient::new(HlConfig::mainnet(), signer)
+}
+
+#[tokio::test]
+async fn live_mainnet_place_cancel_eth_round_trip() {
+    let client = make_client();
+    let master = master_address();
+
+    // === pre-snapshot ===
+    let pre_default = client
+        .fetch_account_state(&master, None)
+        .await
+        .expect("fetch default state pre");
+    let pre_xyz = client
+        .fetch_account_state(&master, Some("xyz"))
+        .await
+        .expect("fetch xyz state pre");
+    let pre_xyz_orders = client
+        .fetch_open_orders(&master, Some("xyz"))
+        .await
+        .expect("fetch xyz orders pre");
+
+    eprintln!(
+        "PRE: default positions={}, xyz positions={}, xyz orders={}",
+        pre_default.positions.len(),
+        pre_xyz.positions.len(),
+        pre_xyz_orders.len()
+    );
+
+    // === ETH index resolve via fetch_meta (PR-A path) ===
+    let meta = client.fetch_meta(None).await.expect("fetch meta");
+    let eth_idx = meta
+        .universe
+        .iter()
+        .position(|u| u.name == "ETH")
+        .expect("ETH not in default perp universe") as u32;
+    eprintln!("ETH asset index: {}", eth_idx);
+
+    // === best price ===
+    let book = client
+        .fetch_book_snapshot(&Symbol::new("ETH"))
+        .await
+        .expect("fetch ETH book");
+    let best_bid = book.best_bid().expect("ETH bid present");
+    let order_px = best_bid * PRICE_OFFSET_RATIO;
+    let notional = order_px * ORDER_SZ_ETH;
+    assert!(
+        notional < MAX_NOTIONAL_USD,
+        "size cap violated: notional ${} >= max ${}",
+        notional,
+        MAX_NOTIONAL_USD
+    );
+    eprintln!(
+        "ETH best_bid={}, order_px={} (1% below), notional≈${}",
+        best_bid, order_px, notional
+    );
+
+    // === place ALO post-only ===
+    let cloid = Cloid::new();
+    let intent = OrderIntent {
+        cloid,
+        symbol: Symbol::new("ETH"),
+        asset: eth_idx,
+        side: Side::Long,
+        px: order_px,
+        sz: ORDER_SZ_ETH,
+        tif: Tif::Alo,
+        reduce_only: false,
+    };
+    let place_resp = client
+        .place_orders(&[intent.clone()])
+        .await
+        .expect("place_orders network/sign error");
+    assert_eq!(place_resp.len(), 1, "expected 1 response");
+    let pr = &place_resp[0];
+    eprintln!(
+        "PLACE: status={}, oid={:?}, error={:?}",
+        pr.status, pr.oid, pr.error
+    );
+
+    // r/s padding diagnostic — surface signature rejection clearly
+    if pr.status == "error" {
+        let msg = pr.error.as_deref().unwrap_or("");
+        if msg.to_lowercase().contains("signature") {
+            panic!("SIGNATURE REJECTED — likely r/s padding issue. msg={msg}");
+        }
+        panic!("place rejected with non-signature error: {msg}");
+    }
+    if pr.status == "filled" {
+        panic!(
+            "UNEXPECTED FILL — manual recovery required (oid={:?}, cloid={})",
+            pr.oid, cloid
+        );
+    }
+    assert_eq!(pr.status, "resting", "expected resting, got {}", pr.status);
+    let oid = pr.oid.expect("resting must have oid");
+
+    // brief wait so HL has time to reflect the open order on the API
+    tokio::time::sleep(Duration::from_millis(POST_PLACE_WAIT_MS)).await;
+
+    // === cancel by cloid ===
+    let cancel = CancelIntent {
+        symbol: Symbol::new("ETH"),
+        asset: eth_idx,
+        by_cloid: Some(cloid),
+        by_oid: None,
+    };
+    let cancel_resp = client
+        .cancel_orders(&[cancel])
+        .await
+        .expect("cancel_orders network/sign error");
+    assert_eq!(cancel_resp.len(), 1);
+    let cr = &cancel_resp[0];
+    eprintln!("CANCEL: status={}, error={:?}", cr.status, cr.error);
+    assert_eq!(
+        cr.status, "cancelled",
+        "expected cancelled, got {} (manual cleanup may be required, oid={})",
+        cr.status, oid
+    );
+
+    // === post-snapshot ===
+    let post_default = client
+        .fetch_account_state(&master, None)
+        .await
+        .expect("fetch default state post");
+    let post_xyz = client
+        .fetch_account_state(&master, Some("xyz"))
+        .await
+        .expect("fetch xyz state post");
+    let post_xyz_orders = client
+        .fetch_open_orders(&master, Some("xyz"))
+        .await
+        .expect("fetch xyz orders post");
+
+    eprintln!(
+        "POST: default positions={}, xyz positions={}, xyz orders={}",
+        post_default.positions.len(),
+        post_xyz.positions.len(),
+        post_xyz_orders.len()
+    );
+
+    // === diff guard: HYPE szi unchanged ===
+    let hype_pre = pre_default.positions.get(&Symbol::new("HYPE"));
+    let hype_post = post_default.positions.get(&Symbol::new("HYPE"));
+    match (hype_pre, hype_post) {
+        (Some(p1), Some(p2)) => assert_eq!(p1.size, p2.size, "HYPE szi changed!"),
+        (None, None) => eprintln!("HYPE absent in both pre/post (ok if user closed it)"),
+        _ => panic!("HYPE pre/post mismatch (one side absent)"),
+    }
+
+    // === diff guard: xyz:META szi unchanged ===
+    let meta_pre = pre_xyz.positions.get(&Symbol::new("xyz:META"));
+    let meta_post = post_xyz.positions.get(&Symbol::new("xyz:META"));
+    match (meta_pre, meta_post) {
+        (Some(p1), Some(p2)) => assert_eq!(p1.size, p2.size, "xyz:META szi changed!"),
+        (None, None) => eprintln!("xyz:META absent in both pre/post"),
+        _ => panic!("xyz:META pre/post mismatch (one side absent)"),
+    }
+
+    // === diff guard: xyz:GOOGL open order oids unchanged ===
+    let mut googl_pre: Vec<u64> = pre_xyz_orders
+        .iter()
+        .filter(|o| o.symbol.as_str() == "xyz:GOOGL")
+        .map(|o| o.oid.0)
+        .collect();
+    let mut googl_post: Vec<u64> = post_xyz_orders
+        .iter()
+        .filter(|o| o.symbol.as_str() == "xyz:GOOGL")
+        .map(|o| o.oid.0)
+        .collect();
+    googl_pre.sort_unstable();
+    googl_post.sort_unstable();
+    assert_eq!(googl_pre, googl_post, "xyz:GOOGL open orders changed!");
+
+    eprintln!(
+        "✓ mainnet round trip success: place oid={} → cancel cloid={}",
+        oid.0, cloid
+    );
+}

--- a/executor/crates/executor-hl/tests/live_mainnet_place_cancel.rs
+++ b/executor/crates/executor-hl/tests/live_mainnet_place_cancel.rs
@@ -19,11 +19,7 @@
 //! the Claude session — only the user's interactive shell.
 
 #![cfg(feature = "live")]
-#![allow(
-    clippy::unwrap_used,
-    clippy::expect_used,
-    clippy::cloned_ref_to_slice_refs
-)]
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 
 use executor_core::cloid::Cloid;
 use executor_core::intent::{CancelIntent, OrderIntent};
@@ -129,7 +125,7 @@ async fn live_mainnet_place_cancel_eth_round_trip() {
         reduce_only: false,
     };
     let place_resp = client
-        .place_orders(&[intent.clone()])
+        .place_orders(std::slice::from_ref(&intent))
         .await
         .expect("place_orders network/sign error");
     assert_eq!(place_resp.len(), 1, "expected 1 response");

--- a/executor/crates/executor-hl/tests/live_mainnet_place_cancel.rs
+++ b/executor/crates/executor-hl/tests/live_mainnet_place_cancel.rs
@@ -33,17 +33,20 @@ use secrecy::SecretString;
 use std::sync::Arc;
 use std::time::Duration;
 
-/// HL enforces a minimum order notional of $10. We pick 0.005 ETH so that at
-/// $2000-$3000/ETH the notional sits comfortably above $10 (~$11-$15) and well
-/// under MAX_NOTIONAL_USD. With 10x leverage this is ~$1.5 margin — trivial
-/// against the master EOA's withdrawable balance.
-const MAX_NOTIONAL_USD: Decimal = dec!(20);
+/// HL enforces a minimum order notional of $10. We target ~$15 by computing
+/// size dynamically from the live ETH price, so the test stays correct
+/// regardless of where ETH trades (the previous fixed `0.005` would Fail
+/// outside the $2000-$4000 ETH range).
+const TARGET_NOTIONAL_USD: Decimal = dec!(15);
+const MAX_NOTIONAL_USD: Decimal = dec!(50);
 const MIN_NOTIONAL_USD: Decimal = dec!(10);
-const ORDER_SZ_ETH: Decimal = dec!(0.005);
+/// Sanity bounds for the observed tick. ETH typical tick is $0.1; if the book
+/// L1-L2 gap is wildly outside this range the book is too thin to use as a
+/// tick proxy and we fail loudly instead of silently sending a malformed price.
+const MIN_OBSERVED_TICK_USD: Decimal = dec!(0.05);
+const MAX_OBSERVED_TICK_USD: Decimal = dec!(0.5);
 /// Number of ticks below best_bid to place the ALO post-only order.
-/// HL ETH typical tick = $0.1 → 100 ticks = $10 (~0.4% below best_bid),
-/// well below cross threshold while staying inside HL's 5-sig-fig + szDecimals
-/// price-formatting constraints (we use the bid grid which is HL-valid by construction).
+/// 100 ticks at typical $0.1 tick = ~$10 below (~0.4% safety distance).
 const TICKS_BELOW_BID: usize = 100;
 const POST_PLACE_WAIT_MS: u64 = 200;
 
@@ -105,11 +108,12 @@ async fn live_mainnet_place_cancel_eth_round_trip() {
     // === best price + tick-based offset ===
     //
     // HL price formatting requires (a) max 5 significant figures, (b) max
-    // (6 - szDecimals) decimal places. Computing `best_bid * 0.99` typically
-    // produces too many sig figs (e.g. 2384.7 * 0.99 = 2360.853). To stay
-    // HL-valid by construction, we observe the actual tick from the bid grid
-    // (level[0].px - level[1].px) and step `TICKS_BELOW_BID` ticks down from
-    // best_bid — that price is always on HL's grid.
+    // (6 - szDecimals) decimal places. `best_bid * 0.99` typically produces
+    // too many sig figs (e.g. 2384.7 * 0.99 = 2360.853). To stay HL-valid by
+    // construction, we observe the tick from the bid grid (level[0].px -
+    // level[1].px) and step `TICKS_BELOW_BID` ticks down — that price is
+    // always on HL's grid. We also bound the observed tick: a thin book where
+    // the L1-L2 gap is far from typical is rejected via assert.
     let book = client
         .fetch_book_snapshot(&Symbol::new("ETH"))
         .await
@@ -117,22 +121,36 @@ async fn live_mainnet_place_cancel_eth_round_trip() {
     let best_bid = book.best_bid().expect("ETH bid present");
     assert!(
         book.bids.len() >= 2,
-        "need at least 2 bid levels to derive tick"
+        "need at least 2 bid levels to derive tick (got {} levels)",
+        book.bids.len()
     );
     let tick = book.bids[0].px - book.bids[1].px;
     assert!(
-        tick > Decimal::ZERO,
-        "tick must be positive: bids[0]={}, bids[1]={}",
+        tick >= MIN_OBSERVED_TICK_USD && tick <= MAX_OBSERVED_TICK_USD,
+        "observed tick ${} outside sanity range [${}, ${}] — book may be thin/abnormal: \
+         bids[0]={} bids[1]={}",
+        tick,
+        MIN_OBSERVED_TICK_USD,
+        MAX_OBSERVED_TICK_USD,
         book.bids[0].px,
         book.bids[1].px
     );
     let order_px = best_bid - tick * Decimal::from(TICKS_BELOW_BID);
-    let notional = order_px * ORDER_SZ_ETH;
+
+    // Compute size dynamically from current price so notional ≈ TARGET regardless
+    // of where ETH trades. ETH szDecimals=4 (verified via meta) so we round
+    // to 4 decimals. truncating ToZero ensures we stay below the target rather
+    // than overshooting.
+    let raw_sz = TARGET_NOTIONAL_USD / order_px;
+    let order_sz = raw_sz.round_dp_with_strategy(4, rust_decimal::RoundingStrategy::ToZero);
+    let notional = order_px * order_sz;
     assert!(
         notional >= MIN_NOTIONAL_USD,
-        "below HL min: notional ${} < min ${}",
+        "below HL min: notional ${} < min ${} (sz={}, px={})",
         notional,
-        MIN_NOTIONAL_USD
+        MIN_NOTIONAL_USD,
+        order_sz,
+        order_px
     );
     assert!(
         notional < MAX_NOTIONAL_USD,
@@ -142,8 +160,16 @@ async fn live_mainnet_place_cancel_eth_round_trip() {
     );
     let safety_pct = (best_bid - order_px) / best_bid * dec!(100);
     eprintln!(
-        "ETH best_bid={}, tick={}, order_px={} ({} ticks below, ≈{:.2}% safety), notional≈${}",
-        best_bid, tick, order_px, TICKS_BELOW_BID, safety_pct, notional
+        "ETH best_bid={}, tick={}, order_px={} ({} ticks below, ≈{:.2}% safety), \
+         sz={} (target ${}), notional≈${}",
+        best_bid,
+        tick,
+        order_px,
+        TICKS_BELOW_BID,
+        safety_pct,
+        order_sz,
+        TARGET_NOTIONAL_USD,
+        notional
     );
 
     // === place ALO post-only ===
@@ -154,7 +180,7 @@ async fn live_mainnet_place_cancel_eth_round_trip() {
         asset: eth_idx,
         side: Side::Long,
         px: order_px,
-        sz: ORDER_SZ_ETH,
+        sz: order_sz,
         tif: Tif::Alo,
         reduce_only: false,
     };
@@ -183,7 +209,12 @@ async fn live_mainnet_place_cancel_eth_round_trip() {
             pr.oid, cloid
         );
     }
-    assert_eq!(pr.status, "resting", "expected resting, got {}", pr.status);
+    assert_eq!(
+        pr.status, "resting",
+        "expected resting, got {} (cloid={}, oid={:?}, error={:?}) — \
+         if oid is Some, an order may be open on HL UI requiring manual cancel",
+        pr.status, cloid, pr.oid, pr.error
+    );
     let oid = pr.oid.expect("resting must have oid");
 
     // brief wait so HL has time to reflect the open order on the API

--- a/executor/crates/executor-hl/tests/live_mainnet_place_cancel.rs
+++ b/executor/crates/executor-hl/tests/live_mainnet_place_cancel.rs
@@ -35,7 +35,11 @@ use std::time::Duration;
 
 const MAX_NOTIONAL_USD: Decimal = dec!(5);
 const ORDER_SZ_ETH: Decimal = dec!(0.001);
-const PRICE_OFFSET_RATIO: Decimal = dec!(0.99);
+/// Number of ticks below best_bid to place the ALO post-only order.
+/// HL ETH typical tick = $0.1 → 100 ticks = $10 (~0.4% below best_bid),
+/// well below cross threshold while staying inside HL's 5-sig-fig + szDecimals
+/// price-formatting constraints (we use the bid grid which is HL-valid by construction).
+const TICKS_BELOW_BID: usize = 100;
 const POST_PLACE_WAIT_MS: u64 = 200;
 
 fn master_address() -> Address {
@@ -93,13 +97,31 @@ async fn live_mainnet_place_cancel_eth_round_trip() {
         .expect("ETH not in default perp universe") as u32;
     eprintln!("ETH asset index: {}", eth_idx);
 
-    // === best price ===
+    // === best price + tick-based offset ===
+    //
+    // HL price formatting requires (a) max 5 significant figures, (b) max
+    // (6 - szDecimals) decimal places. Computing `best_bid * 0.99` typically
+    // produces too many sig figs (e.g. 2384.7 * 0.99 = 2360.853). To stay
+    // HL-valid by construction, we observe the actual tick from the bid grid
+    // (level[0].px - level[1].px) and step `TICKS_BELOW_BID` ticks down from
+    // best_bid — that price is always on HL's grid.
     let book = client
         .fetch_book_snapshot(&Symbol::new("ETH"))
         .await
         .expect("fetch ETH book");
     let best_bid = book.best_bid().expect("ETH bid present");
-    let order_px = best_bid * PRICE_OFFSET_RATIO;
+    assert!(
+        book.bids.len() >= 2,
+        "need at least 2 bid levels to derive tick"
+    );
+    let tick = book.bids[0].px - book.bids[1].px;
+    assert!(
+        tick > Decimal::ZERO,
+        "tick must be positive: bids[0]={}, bids[1]={}",
+        book.bids[0].px,
+        book.bids[1].px
+    );
+    let order_px = best_bid - tick * Decimal::from(TICKS_BELOW_BID);
     let notional = order_px * ORDER_SZ_ETH;
     assert!(
         notional < MAX_NOTIONAL_USD,
@@ -107,9 +129,10 @@ async fn live_mainnet_place_cancel_eth_round_trip() {
         notional,
         MAX_NOTIONAL_USD
     );
+    let safety_pct = (best_bid - order_px) / best_bid * dec!(100);
     eprintln!(
-        "ETH best_bid={}, order_px={} (1% below), notional≈${}",
-        best_bid, order_px, notional
+        "ETH best_bid={}, tick={}, order_px={} ({} ticks below, ≈{:.2}% safety), notional≈${}",
+        best_bid, tick, order_px, TICKS_BELOW_BID, safety_pct, notional
     );
 
     // === place ALO post-only ===


### PR DESCRIPTION
## Summary

Stage B step 2b (PR-B2b) of the C-1 段階的検証 spec. **First successful HL mainnet POST in this project.** Executed manually by the user from a shell where `source scripts/load-env.sh` had loaded `HL_AGENT_PK` from pass-store.

- Single new file `tests/live_mainnet_place_cancel.rs` under `#[cfg(feature = "live")]`.
- ETH ~\$15 (dynamic-size) post-only ALO @ best_bid - 100 ticks → cloid cancel.
- ETH asset index resolved via `fetch_meta()` (PR-A read-only path integration verified).
- Tick observed from book L1-L2 gap with sanity bounds [\$0.05, \$0.5] (Gemini MUST-FIX 1).
- Size computed dynamically from TARGET_NOTIONAL_USD/order_px to handle any ETH price (Gemini MUST-FIX 2).
- 4 safety layers (per spec §4.2): symbol allowlist, size cap (notional in [MIN $10, MAX $50]), pre/post diff guard on HYPE/xyz:META/xyz:GOOGL, best-far ALO post-only.

## Live run output (実機 mainnet, 2026-05-05)

```
PRE: default positions=0, xyz positions=1, xyz orders=1
ETH asset index: 1
ETH best_bid=2381.8, tick=0.1, order_px=2371.8 (100 ticks below, ≈0.41% safety), notional≈\$11.8590
PLACE: status=resting, oid=Some(OrderId(411376566471)), error=None
CANCEL: status=cancelled, error=None
POST: default positions=0, xyz positions=1, xyz orders=1
HYPE absent in both pre/post (ok if user closed it)
✓ mainnet round trip success: place oid=411376566471 → cancel cloid=0x019df71c34767460af0e396f0c4c3ab6
```

(Note: this 1st successful run used the old hardcoded sz=0.005. The Gemini-fix commit added dynamic sizing for robustness across any ETH price; the underlying signing/wire path is the same as what was verified live.)

## Implementation iterations on the live test

The mainnet round-trip succeeded only after 3 iterations:

1. **Iteration 1**: \`best_bid * 0.99\` → "Order has invalid price" (HL price format: 5 sig fig + 2 decimals max for ETH).
   Fix (commit 372e570): tick-grid pricing using observed bid L1-L2 gap.

2. **Iteration 2**: 0.001 ETH × \$2380 = \$2.38 → "Order must have minimum value of \$10".
   Fix (commit 607c834): bumped to 0.005 ETH (~\$12).

3. **Iteration 3 (live success)**: place_resting + cancel_cancelled, diff guard PASS.

4. **Gemini deep review fixes (commit 8d70de5)** — applied AFTER successful live run, no re-run needed since they only harden the test:
   - tick sanity bounds (a thin book would have failed silently before)
   - dynamic sizing (test will keep working as ETH price drifts)
   - panic message includes oid (post-mortem cleanup info)

## Verified by this PR

- ✅ `r/s` padding (Rust 64-hex padded) is **accepted** by HL `/exchange` (PR-B1's deferred padding question is now answered).
- ✅ `OrderAction` wire format ↔ HL parser interop.
- ✅ `CancelByCloidAction` wire format ↔ HL parser interop.
- ✅ `parse_exchange_response` correctly extracts `resting` shape from real HL.
- ✅ `parse_cancel_response` correctly extracts `"success"` from real HL.
- ✅ Existing positions byte-identical pre/post (xyz:META szi unchanged, xyz:GOOGL oid unchanged).

## Test plan

- [x] `cargo test -p executor-hl` (no `--features live`) — `live_mainnet_place_cancel` not listed (cfg-gated)
- [x] `cargo test -p executor-hl --features live live_mainnet_place_cancel -- --list` — test listed
- [x] `cargo build -p executor-hl --tests --features live` — clean
- [x] `cargo clippy -p executor-hl --tests --features live -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] **User-executed live run**: place resting → cancel cancelled → diff guard PASS → "✓ mainnet round trip success"

## Notes

- This PR adds **no production code changes**. Production code is unchanged from PR-B2a.
- The Claude PreToolUse hook physically prevents the Claude session from running this test (it blocks `source scripts/load-env.sh` and `pass show`). The test code is committed for reproducibility; only the user can run it.
- Total HL impact: 1 place + 1 cancel = 2 `/exchange` POSTs, ~\$0 fees (post-only ALO + immediate cancel).

## Deferred to PR-C (executor-server production path)

- `executor-server` integration: production code path with `--mainnet-allow-symbols` flag, server-internal baseline-diff guard, asset cache via `fetch_meta` startup.
- emergency_stop multi-symbol cancel real-environment test.
- by-oid cancel path for cases where cloid is unknown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)