### PR TITLE
feat(executor): PR-C2 — mainnet safety gate (allowlist + size cap)

### DIFF
--- a/docs/HANDOFF-2026-05-05.md
+++ b/docs/HANDOFF-2026-05-05.md
@@ -325,4 +325,75 @@ HL_TEST_ADDRESS=0xfe3e32cd4443e395ec0400bf828a34309e517d2d \
 
 何か壊れていたら develop に戻して状態を確認.
 
+---
+
+## 10. PR-C2 完了 (2026-05-05, mainnet safety gate)
+
+### 完了 PR
+- PR #74 想定: `feat(executor): PR-C2 — mainnet safety gate (symbol allowlist + size cap)`
+- branch: `feat/pr-c2-mainnet-safety-gate`
+- spec: `docs/superpowers/specs/2026-05-05-pr-c2-symbol-allowlist-size-cap-design.md`
+- plan: `docs/superpowers/plans/2026-05-05-pr-c2-symbol-allowlist-size-cap-plan.md`
+
+### Gemini deep review でフリップした論点 (review_log:awei5shyz83tjs2lxpu3)
+- **Q3**: mainnet+real で `--mainnet-allow-symbols=""` は **fatal error 起動拒否** に変更 (Claude 案は warn, Gemini が「金融系で warn は見落とされる」で flip)
+- **Q4**: `--mainnet-max-notional-usd` は **`Option<u64>`** (Claude 案は `u64=0` sentinel, Gemini が「アンチパターン」で flip)
+- 他 6 論点 (Q1,Q2,Q5,Q6,Q7,Q8) は Claude 推奨を Gemini が同意
+
+### 追加 CLI flag
+```
+--mainnet-allow-symbols ETH,BTC          # mainnet+real で必須. '*' = 明示 allow-all
+--mainnet-max-notional-usd 20            # 省略可 (None = no cap)
+```
+両 flag は env 変数 `EXECUTOR_MAINNET_ALLOW_SYMBOLS` / `EXECUTOR_MAINNET_MAX_NOTIONAL_USD` でも設定可.
+
+### 2 段防御の構造
+
+| Layer | 場所 | 検査タイミング |
+|---|---|---|
+| 1 | `routes.rs::start_exec` (REST 入口) | symbol allow-list + 概算 notional (book.best_bid 基準) で 400 即時拒否 |
+| 2 | `BatchSender::enqueue` (executor-hl 内部) | algo 動的生成 `OrderIntent` を `IntentChecker` trait 経由で再検査. 違反は drop + `HlError::ActionFormat` |
+
+mock mode は `SafetyGate::disabled()` + `gate=None` で全通過 (CI 既存テスト無影響).
+`OrderOrCancel::Cancel` は gate を通さず即素通し (`emergency_stop` 確実動作).
+
+### 起動例
+```bash
+# mainnet 本運用 (推奨)
+cargo run -p executor-server -- --mode real --base mainnet \
+  --mainnet-allow-symbols ETH \
+  --mainnet-max-notional-usd 20
+
+# fatal 例 (mainnet+real+allow-list 空)
+cargo run -p executor-server -- --mode real --base mainnet
+# → Error: --mainnet-allow-symbols is required for --mode real --base mainnet.
+
+# mock (CI / 開発)
+cargo run -p executor-server -- --mode mock     # gate disabled
+```
+
+### テスト集計 (PR-C2 後)
+| 区分 | 件数 |
+|---|---|
+| Rust workspace | **164 tests pass** (HANDOFF 145 から +19) |
+| 内訳 (新規) | safety::tests +13, batch_sender::tests gate +3, integration_rest +3 |
+
+`cargo fmt --check` / `cargo clippy -D warnings` / `scripts/check_ci_local.sh` 全クリーン.
+
+### 重要設計ファイル (PR-C2)
+
+| 機能 | パス |
+|---|---|
+| IntentChecker trait | `executor/crates/executor-hl/src/intent_checker.rs` |
+| BatchSender gate 統合 | `executor/crates/executor-hl/src/batch_sender.rs::spawn_batch_sender_with_gate` |
+| SafetyGate 構造体 | `executor/crates/executor-server/src/safety.rs` |
+| Layer 1 注入点 | `executor/crates/executor-server/src/routes.rs::start_exec` |
+| 起動シーケンス | `executor/crates/executor-server/src/main.rs::main` |
+
+### 次セッション (PR-C3 想定)
+- baseline-diff guard: 起動時に master EOA の HYPE / xyz:META / xyz:GOOGL ポジを snapshot, 60s 毎 diff → 違反検知で自動 emergency_stop
+- 「片肺リスク」(複数注文一部失敗) と組み合わせて 2 段目 safety
+- PR-C4 で multi-symbol live test + e2e
+
 完.
+

--- a/docs/superpowers/plans/2026-05-05-pr-c2-symbol-allowlist-size-cap-plan.md
+++ b/docs/superpowers/plans/2026-05-05-pr-c2-symbol-allowlist-size-cap-plan.md
@@ -1,0 +1,489 @@
+# PR-C2: symbol allowlist + size cap (mainnet safety gate) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a 2-layer defense-in-depth safety gate to `executor-server` that rejects orders for non-allow-listed symbols and orders exceeding a configured per-order USD notional cap. Layer 1 fires at the REST entry (`POST /v1/exec`) using `book.best_bid` as a rough reference price. Layer 2 fires at `BatchSender::enqueue` time using the actual `OrderIntent.px`. Mock mode runs with the gate disabled (no test impact). Mainnet-real mode requires `--mainnet-allow-symbols` to be set; an empty value makes startup fatal. The wildcard `*` opts in to allow-all explicitly. `OrderOrCancel::Cancel` always passes through (emergency_stop must work).
+
+**Architecture:** A new `IntentChecker` trait lives in `executor-hl::intent_checker` (shape: `fn check_place(&self, &OrderIntent) -> Result<(), String>`). `BatchSender` gains an optional `Option<Arc<dyn IntentChecker>>` field; the existing `spawn_batch_sender` becomes a thin wrapper that calls a new `spawn_batch_sender_with_gate`. The concrete `SafetyGate` struct lives in `executor-server::safety`, holds `Option<HashSet<Symbol>>` and `Option<Decimal>`, and implements `IntentChecker`. The startup path (`main.rs`) parses CLI flags via `clap`, builds the gate via `SafetyGate::from_args`, registers it on the `BatchSender` (only in real mode) and in `ServerState`. The `start_exec` route handler reads `book.best_bid` and calls `safety.check_request` before dispatching the algo.
+
+**Tech Stack:** Rust 2021 (workspace MSRV 1.91), no new deps. Existing: `clap 4 derive+env`, `rust_decimal 1.x`, `thiserror 1.x`, `tokio 1.x`, `tower 0.5`. Tests use `mockito 1.7` (existing) for HTTP mocks, `tower::ServiceExt::oneshot` for axum integration.
+
+---
+
+## File Structure
+
+| Path | Responsibility | Action |
+|---|---|---|
+| `executor/crates/executor-hl/src/intent_checker.rs` | NEW. Defines `IntentChecker` trait. ~10 LOC. | Create |
+| `executor/crates/executor-hl/src/lib.rs` | Add `pub mod intent_checker;` and re-export `pub use intent_checker::IntentChecker;`. | Modify |
+| `executor/crates/executor-hl/src/batch_sender.rs` | Add `gate: Option<Arc<dyn IntentChecker>>` field on `BatchSender`. New constructor `spawn_batch_sender_with_gate`. Existing `spawn_batch_sender` becomes a thin wrapper passing `gate=None`. `enqueue` and `enqueue_with_ack` consult the gate for `OrderOrCancel::Place` and reject violations with `HlError::ActionFormat`. Manual `Debug` impl for `BatchSender` (because `dyn IntentChecker: !Debug` by default). 3 new tests. | Modify |
+| `executor/crates/executor-server/src/safety.rs` | NEW. `SafetyGate` struct, `SafetyViolation` enum, `from_args` constructor, `check_request`/`check_intent` methods, `impl IntentChecker for SafetyGate`. ~150 LOC + 8 unit tests. | Create |
+| `executor/crates/executor-server/src/lib.rs` | Add `pub mod safety;` and re-export `pub use safety::{SafetyGate, SafetyViolation};`. | Modify |
+| `executor/crates/executor-server/src/state.rs` | Add `pub safety: Arc<SafetyGate>` field to `ServerState`. Update `ServerState::new` signature to accept `safety: Arc<SafetyGate>`. | Modify |
+| `executor/crates/executor-server/src/routes.rs` | In `start_exec`, after `validate_algorithm_name`, call `safety.check_request` using `book.best_bid` as `ref_px`. Return `400 Bad Request` on violation. | Modify |
+| `executor/crates/executor-server/src/main.rs` | Add 2 new CLI flags. Construct `SafetyGate` via `from_args` (panic on mainnet-real with empty allow-list). Pass `Option<Arc<dyn IntentChecker>>` into `spawn_batch_sender_with_gate`. Pass `Arc<SafetyGate>` into `ServerState::new`. | Modify |
+| `executor/crates/executor-server/tests/integration_rest.rs` | Update `build_state_with_seed` to pass `Arc::new(SafetyGate::disabled())` to `ServerState::new`. Add 3 new tests with non-disabled gates. | Modify |
+| `docs/superpowers/specs/2026-05-05-pr-c2-symbol-allowlist-size-cap-design.md` | Already created — reference doc. | (already done) |
+| `docs/HANDOFF-2026-05-05.md` | Append PR-C2 完了 subsection at session end. | Modify (last step) |
+
+---
+
+## Step 1: Add `IntentChecker` trait
+
+- [ ] Create `executor/crates/executor-hl/src/intent_checker.rs` with:
+  ```rust
+  //! Pluggable pre-flight check for `OrderIntent` placements.
+  //!
+  //! `BatchSender` consults a gate before enqueueing an `OrderOrCancel::Place`.
+  //! `OrderOrCancel::Cancel` is never gated — emergency_stop must always work.
+  //! The concrete check (e.g. symbol allow-list + size cap) lives in
+  //! `executor-server::safety::SafetyGate` and impls this trait.
+
+  use executor_core::intent::OrderIntent;
+
+  pub trait IntentChecker: std::fmt::Debug + Send + Sync + 'static {
+      /// Inspect the intent. Return `Err(reason)` to drop, `Ok(())` to allow.
+      fn check_place(&self, intent: &OrderIntent) -> Result<(), String>;
+  }
+  ```
+- [ ] In `executor/crates/executor-hl/src/lib.rs`, add `pub mod intent_checker;` and `pub use intent_checker::IntentChecker;` (next to existing `pub mod batch_sender;`).
+- [ ] Verify build: `cd executor && cargo build -p executor-hl`.
+
+## Step 2: Wire gate into `BatchSender`
+
+- [ ] In `executor/crates/executor-hl/src/batch_sender.rs`:
+  - Import: `use crate::intent_checker::IntentChecker;`
+  - Replace `#[derive(Debug, Clone)]` on `BatchSender` with manual `Debug` impl (because `Arc<dyn IntentChecker>` doesn't auto-derive Debug):
+    ```rust
+    #[derive(Clone)]
+    pub struct BatchSender {
+        tx: mpsc::Sender<Envelope>,
+        gate: Option<Arc<dyn IntentChecker>>,
+    }
+
+    impl std::fmt::Debug for BatchSender {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.debug_struct("BatchSender")
+                .field("gate", &self.gate.is_some())
+                .finish()
+        }
+    }
+    ```
+  - Modify `enqueue`:
+    ```rust
+    pub fn enqueue(&self, item: OrderOrCancel) -> Result<(), HlError> {
+        if let Some(gate) = &self.gate {
+            if let OrderOrCancel::Place(intent) = &item {
+                if let Err(reason) = gate.check_place(intent) {
+                    tracing::error!(
+                        reason, cloid = ?intent.cloid, symbol = %intent.symbol,
+                        "safety_gate: drop place"
+                    );
+                    return Err(HlError::ActionFormat(format!("safety_gate: {reason}")));
+                }
+            }
+        }
+        self.tx
+            .try_send(Envelope { item, ack: None })
+            .map_err(|e| HlError::Network(format!("batch enqueue: {e}")))
+    }
+    ```
+  - Modify `enqueue_with_ack` similarly (gate check before sending the envelope; return `Err(HlError::ActionFormat)` so the caller's `oneshot::Receiver` resolves to that error in the same way as a flusher-side failure).
+  - Add new function:
+    ```rust
+    pub fn spawn_batch_sender_with_gate<C>(
+        client: Arc<C>,
+        gate: Option<Arc<dyn IntentChecker>>,
+        cfg: BatchSenderConfig,
+    ) -> (BatchSender, BatchSenderHandle)
+    where
+        C: HlClient + 'static,
+    {
+        let (tx, rx) = mpsc::channel(1024);
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let join = tokio::spawn(flusher_loop(client, rx, cfg, shutdown_rx));
+        (
+            BatchSender { tx, gate },
+            BatchSenderHandle { join, shutdown: shutdown_tx },
+        )
+    }
+    ```
+  - Refactor existing `spawn_batch_sender` to call `spawn_batch_sender_with_gate(client, None, cfg)`.
+- [ ] Verify build: `cargo build -p executor-hl`.
+
+## Step 3: BatchSender unit tests for the gate
+
+- [ ] In `executor/crates/executor-hl/src/batch_sender.rs::tests`, add 3 tests:
+  - `enqueue_with_gate_rejects_violation`: define a mock `RejectAll` checker → expect `Err(HlError::ActionFormat(...))` from `enqueue`.
+  - `enqueue_with_gate_passes_ok`: define a mock `AllowAll` checker → enqueue + flush + assert mock client received the order.
+  - `enqueue_cancel_skips_gate`: gate present (`RejectAll`), enqueue `OrderOrCancel::Cancel` → must succeed.
+  - Helper inside test mod:
+    ```rust
+    #[derive(Debug)]
+    struct AllowAll;
+    impl IntentChecker for AllowAll {
+        fn check_place(&self, _: &OrderIntent) -> Result<(), String> { Ok(()) }
+    }
+    #[derive(Debug)]
+    struct RejectAll;
+    impl IntentChecker for RejectAll {
+        fn check_place(&self, _: &OrderIntent) -> Result<(), String> {
+            Err("blocked by test".into())
+        }
+    }
+    ```
+- [ ] Run: `cargo test -p executor-hl batch_sender`.
+
+## Step 4: SafetyGate struct in executor-server
+
+- [ ] Create `executor/crates/executor-server/src/safety.rs`:
+  ```rust
+  //! Mainnet safety gate: symbol allow-list + per-order USD notional cap.
+  //!
+  //! Wires into the BatchSender via the `IntentChecker` trait at startup.
+  //! Mock mode constructs a `disabled()` gate which short-circuits all checks.
+  //! Real mode requires `--mainnet-allow-symbols` to be set when targeting
+  //! mainnet; an empty value makes startup fatal.
+
+  use std::collections::HashSet;
+
+  use rust_decimal::Decimal;
+  use thiserror::Error;
+
+  use executor_core::intent::OrderIntent;
+  use executor_core::symbol::Symbol;
+  use executor_hl::IntentChecker;
+
+  #[derive(Debug, Clone)]
+  pub struct SafetyGate {
+      /// `None` = no symbol allow-list (everything passes).
+      /// `Some(set)` = only symbols in the set are allowed.
+      pub allow_symbols: Option<HashSet<Symbol>>,
+      /// `None` = no notional cap. `Some(usd)` = max per-order notional (USD).
+      pub max_notional_usd: Option<Decimal>,
+  }
+
+  #[derive(Debug, Clone, Error)]
+  pub enum SafetyViolation {
+      #[error("symbol_not_allowed: symbol={symbol}, allowed={allowed:?}")]
+      SymbolNotAllowed {
+          symbol: Symbol,
+          allowed: Vec<Symbol>,
+      },
+      #[error("notional_exceeded: symbol={symbol}, notional={notional}, max={max}")]
+      NotionalExceeded {
+          symbol: Symbol,
+          notional: Decimal,
+          max: Decimal,
+      },
+  }
+
+  impl SafetyGate {
+      /// Mock mode / explicit allow-all. Everything passes.
+      pub fn disabled() -> Self {
+          Self {
+              allow_symbols: None,
+              max_notional_usd: None,
+          }
+      }
+
+      /// Build from CLI args.
+      ///
+      /// `is_mainnet_real = (mode==real && base==mainnet)`.
+      /// When that's true, an empty `allow_csv` is fatal — Gemini deep review
+      /// (2026-05-05): "warn ログは見落とされる. 金融系では明示 opt-in を要求する".
+      ///
+      /// `allow_csv = "*"` is the explicit opt-in to allow-all.
+      /// `allow_csv = "ETH,BTC"` is the typical case.
+      pub fn from_args(
+          allow_csv: &str,
+          max_usd: Option<u64>,
+          is_mainnet_real: bool,
+      ) -> anyhow::Result<Self> {
+          let trimmed = allow_csv.trim();
+          let allow_symbols = if trimmed.is_empty() {
+              if is_mainnet_real {
+                  anyhow::bail!(
+                      "--mainnet-allow-symbols is required for --mode real --base mainnet. \
+                       Use '*' to explicitly allow-all (NOT recommended for production)."
+                  );
+              }
+              // Non-mainnet-real with empty CSV: keep as Some(empty) so testnet
+              // gate testing has a meaningful "reject everything" config.
+              Some(HashSet::new())
+          } else if trimmed == "*" {
+              None
+          } else {
+              Some(
+                  trimmed
+                      .split(',')
+                      .map(|s| Symbol::new(s.trim().to_string()))
+                      .collect(),
+              )
+          };
+          Ok(Self {
+              allow_symbols,
+              max_notional_usd: max_usd.map(Decimal::from),
+          })
+      }
+
+      /// Layer 1: REST-entry rough check using a reference price (best_bid).
+      /// `ref_px = None` skips the notional check.
+      pub fn check_request(
+          &self,
+          symbol: &Symbol,
+          target_size: Decimal,
+          ref_px: Option<Decimal>,
+      ) -> Result<(), SafetyViolation> {
+          if let Some(allowed) = &self.allow_symbols {
+              if !allowed.contains(symbol) {
+                  return Err(SafetyViolation::SymbolNotAllowed {
+                      symbol: symbol.clone(),
+                      allowed: allowed.iter().cloned().collect(),
+                  });
+              }
+          }
+          if let (Some(max), Some(px)) = (self.max_notional_usd, ref_px) {
+              let notional = px * target_size;
+              if notional > max {
+                  return Err(SafetyViolation::NotionalExceeded {
+                      symbol: symbol.clone(),
+                      notional,
+                      max,
+                  });
+              }
+          }
+          Ok(())
+      }
+
+      /// Layer 2: enqueue-time strict check using the order's actual px.
+      pub fn check_intent(&self, o: &OrderIntent) -> Result<(), SafetyViolation> {
+          if let Some(allowed) = &self.allow_symbols {
+              if !allowed.contains(&o.symbol) {
+                  return Err(SafetyViolation::SymbolNotAllowed {
+                      symbol: o.symbol.clone(),
+                      allowed: allowed.iter().cloned().collect(),
+                  });
+              }
+          }
+          if let Some(max) = self.max_notional_usd {
+              let notional = o.px * o.sz;
+              if notional > max {
+                  return Err(SafetyViolation::NotionalExceeded {
+                      symbol: o.symbol.clone(),
+                      notional,
+                      max,
+                  });
+              }
+          }
+          Ok(())
+      }
+  }
+
+  impl IntentChecker for SafetyGate {
+      fn check_place(&self, intent: &OrderIntent) -> Result<(), String> {
+          self.check_intent(intent).map_err(|v| v.to_string())
+      }
+  }
+
+  // ---- tests ----
+  #[cfg(test)]
+  mod tests {
+      // 8 tests as listed in spec §5.1
+  }
+  ```
+- [ ] In `executor/crates/executor-server/src/lib.rs`, add `pub mod safety;` and `pub use safety::{SafetyGate, SafetyViolation};`.
+- [ ] `executor/crates/executor-server/Cargo.toml` には既存 `executor-core` `executor-hl` `rust_decimal` `thiserror` があるはず — 確認のみ. なければ追加.
+- [ ] Run: `cargo build -p executor-server`.
+
+## Step 5: SafetyGate unit tests (8 tests)
+
+- [ ] Add the test module body in `safety.rs` covering spec §5.1:
+  1. `disabled_passes_request`: `disabled().check_request(&Symbol::new("XYZ"), dec!(1), Some(dec!(99999)))` → `Ok(())`.
+  2. `disabled_passes_intent`: `disabled().check_intent(&order_intent)` → `Ok(())`.
+  3. `allow_list_rejects_non_member`: `from_args("ETH,BTC", None, false)` then `check_request(Symbol("XRP"), ...)` → `SymbolNotAllowed`.
+  4. `allow_list_accepts_member`: same gate, `check_request(Symbol("ETH"), dec!(0.001), Some(dec!(2400)))` → `Ok`.
+  5. `notional_cap_rejects_over`: `from_args("ETH", Some(10), false)` then `check_request(Symbol("ETH"), dec!(0.005), Some(dec!(2400)))` → notional=12 > 10 → `NotionalExceeded`.
+  6. `notional_cap_accepts_under`: same gate, `check_request(Symbol("ETH"), dec!(0.004), Some(dec!(2400)))` → notional=9.6 ≤ 10 → `Ok`.
+  7. `from_args_mainnet_real_empty_fatal`: `from_args("", None, true)` → `Err`. Assert error message contains `"required"`.
+  8. `from_args_star_means_allow_all`: `from_args("*", None, true)` → `Ok` and `gate.allow_symbols.is_none()`.
+  Plus 1 extra:
+  9. `from_args_csv_with_whitespace`: `from_args("ETH , BTC ,LINK", None, false)` → `Ok`, all 3 symbols normalized into the set.
+- [ ] Run: `cargo test -p executor-server safety`.
+
+## Step 6: Update `ServerState` to carry the gate
+
+- [ ] In `executor/crates/executor-server/src/state.rs`:
+  - Add field `pub safety: Arc<SafetyGate>` to `ServerState`.
+  - Update `ServerState::new` signature: append `safety: Arc<SafetyGate>` parameter.
+  - Update `Debug` impl: include `safety` (it derives `Debug`).
+- [ ] All call sites of `ServerState::new` will fail to compile until updated. Note them (main.rs + integration_rest.rs).
+
+## Step 7: Update `routes.rs::start_exec` for Layer 1
+
+- [ ] In `executor/crates/executor-server/src/routes.rs::start_exec`, after `validate_algorithm_name(&req.algorithm)?;`:
+  ```rust
+  let symbol = Symbol::new(req.symbol.clone());
+  let ref_px = {
+      let book_g = s.app_state.book.read().await;
+      book_g.get(&symbol).and_then(|b| b.best_bid())
+  };
+  s.safety
+      .check_request(&symbol, req.target_size, ref_px)
+      .map_err(|v| ServerError::BadRequest(format!("safety_gate: {v}")))?;
+  ```
+  - Note: `req.symbol` is moved later into `Symbol::new(req.symbol)` for `ctx.symbol`. Refactor so `let symbol = Symbol::new(req.symbol.clone());` happens once at the top, then reuse it for `ctx.symbol = symbol`.
+- [ ] Run: `cargo build -p executor-server` (will fail at `ServerState::new` call sites — fix in next step).
+
+## Step 8: Update `main.rs`
+
+- [ ] In `executor/crates/executor-server/src/main.rs`:
+  - Add to `Args`:
+    ```rust
+    /// Mainnet allow-list of symbols (comma-separated, e.g. "ETH,BTC").
+    /// REQUIRED for `--mode real --base mainnet`.
+    /// Use `*` to explicitly allow all (NOT recommended for production).
+    #[arg(long, env = "EXECUTOR_MAINNET_ALLOW_SYMBOLS", default_value = "")]
+    mainnet_allow_symbols: String,
+
+    /// Per-order USD notional cap. Omit for no cap (NOT recommended for production).
+    #[arg(long, env = "EXECUTOR_MAINNET_MAX_NOTIONAL_USD")]
+    mainnet_max_notional_usd: Option<u64>,
+    ```
+  - In `main()`, immediately after `let args = Args::parse();` and before `app_state` construction:
+    ```rust
+    let is_mainnet_real = matches!(args.mode, Mode::Real) && matches!(args.base, Base::Mainnet);
+    let safety = Arc::new(match args.mode {
+        Mode::Mock => executor_server::SafetyGate::disabled(),
+        Mode::Real => executor_server::SafetyGate::from_args(
+            &args.mainnet_allow_symbols,
+            args.mainnet_max_notional_usd,
+            is_mainnet_real,
+        ).context("safety gate construction failed")?,
+    });
+    tracing::info!(
+        allow_symbols = ?safety.allow_symbols,
+        max_notional_usd = ?safety.max_notional_usd,
+        "safety gate constructed",
+    );
+    ```
+  - Replace both `spawn_batch_sender(...)` calls with `spawn_batch_sender_with_gate`:
+    ```rust
+    let gate_dyn: Option<Arc<dyn IntentChecker>> = match args.mode {
+        Mode::Mock => None,
+        Mode::Real => Some(safety.clone() as Arc<dyn IntentChecker>),
+    };
+    // (inside Mode::Mock match arm)
+    let (batch_sender, batch_handle) =
+        spawn_batch_sender_with_gate(mock_hl.clone(), None, batch_cfg);
+    // (inside Mode::Real match arm)
+    let (batch_sender, batch_handle) =
+        spawn_batch_sender_with_gate(real_client.clone(), gate_dyn.clone(), batch_cfg);
+    ```
+    - Note: `gate_dyn` is computed once before the match. `Mode::Mock` arm passes `None` literal (the match is exhaustive on mode anyway). Choose: simpler is to keep `gate_dyn` computed and pass it into both arms — `None` in the mock arm, `Some(...)` in the real arm. We can also avoid hoisting `gate_dyn` and just inline `match`.
+  - Update import: `use executor_hl::batch_sender::{spawn_batch_sender_with_gate, BatchSenderConfig};` (drop `spawn_batch_sender` since main no longer uses the no-gate variant).
+  - Add import: `use executor_hl::IntentChecker;`.
+  - Update `ServerState::new(...)` to include `safety.clone()` as the last argument.
+- [ ] Run: `cd executor && cargo build -p executor-server`. Should compile clean.
+
+## Step 9: Update integration tests
+
+- [ ] In `executor/crates/executor-server/tests/integration_rest.rs`:
+  - Add import: `use executor_server::SafetyGate;`.
+  - Modify `build_state_with_seed`:
+    - Append: `let safety = Arc::new(SafetyGate::disabled());`.
+    - Pass `safety` as the 6th argument to `ServerState::new(...)`.
+  - Add helper `build_state_with_safety(safety: SafetyGate) -> (Arc<ServerState>, Arc<MockHlClient>)` that does the same setup but takes a custom gate.
+  - Add 3 new tests:
+    1. `start_exec_symbol_not_allowed_400`:
+       ```rust
+       let safety = SafetyGate::from_args("BTC", None, false).unwrap();
+       let (state, _) = build_state_with_safety(safety).await;
+       // POST to /v1/exec with symbol="ETH" → expect 400 + body contains "safety_gate"
+       ```
+    2. `start_exec_notional_exceeded_400`:
+       ```rust
+       // Seed BTC book at $50000; gate allow=BTC max=$10
+       // Request target_size=0.001 (= $50 notional) → 400
+       ```
+    3. `start_exec_within_caps_200`:
+       ```rust
+       // Same setup; request target_size=0.0001 (= $5) → 200
+       ```
+- [ ] Run: `cargo test -p executor-server`.
+
+## Step 10: Workspace-wide checks
+
+- [ ] `cd executor && cargo fmt --all`.
+- [ ] `cargo build --workspace`.
+- [ ] `cargo test --workspace` — expect ~158-160 tests pass (existing 145 + new ~14).
+- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — must be clean.
+- [ ] `cd .. && bash scripts/check_ci_local.sh` (local CI mirror).
+
+## Step 11: Live validation prep (offline check, no PK access)
+
+- [ ] Verify the new CLI:
+  ```bash
+  cd executor
+  # Should show new flags in --help
+  cargo run -p executor-server -- --help
+  ```
+- [ ] (For user, separate terminal — Claude does NOT run this:)
+  ```bash
+  # Sanity: empty allow-list on mainnet+real → fatal
+  cargo run -p executor-server -- --mode real --base mainnet
+  # Expect: Error: --mainnet-allow-symbols is required ...
+
+  # Sanity: real mode with valid gate → starts
+  source scripts/load-env.sh
+  cargo run -p executor-server -- --mode real --base mainnet \
+    --mainnet-allow-symbols ETH \
+    --mainnet-max-notional-usd 20
+  # Expect: log "safety gate constructed allow_symbols=Some({Symbol(\"ETH\")}) max_notional_usd=Some(20)"
+  ```
+- [ ] (Same, when user has time:) curl tests against the live `--mode real` server:
+  - `curl -XPOST localhost:8085/v1/exec -d '{"algorithm":"market","symbol":"BTC","intent":"open","target_size":"0.0001"}'` → 400
+  - `curl -XPOST localhost:8085/v1/exec -d '{"algorithm":"market","symbol":"ETH","intent":"open","target_size":"5"}'` → 400 (notional > 20)
+  - `curl -XPOST localhost:8085/v1/exec -d '{"algorithm":"market","symbol":"ETH","intent":"open","target_size":"0.001"}'` → 200
+
+## Step 12: Doc updates and commit
+
+- [ ] Append to `docs/HANDOFF-2026-05-05.md` a `## 10. PR-C2 完了` subsection summarizing what shipped, key Gemini-flipped decisions (Q3 fatal, Q4 Option), and the next step (PR-C3).
+- [ ] Commit:
+  ```bash
+  git add docs/superpowers/specs/2026-05-05-pr-c2-symbol-allowlist-size-cap-design.md
+  git add docs/superpowers/plans/2026-05-05-pr-c2-symbol-allowlist-size-cap-plan.md
+  git commit -m "docs(spec/plan): PR-C2 mainnet safety gate (allowlist + size cap) design + plan"
+
+  git add executor/crates/executor-hl/src/intent_checker.rs
+  git add executor/crates/executor-hl/src/lib.rs
+  git add executor/crates/executor-hl/src/batch_sender.rs
+  git add executor/crates/executor-server/src/safety.rs
+  git add executor/crates/executor-server/src/lib.rs
+  git add executor/crates/executor-server/src/state.rs
+  git add executor/crates/executor-server/src/routes.rs
+  git add executor/crates/executor-server/src/main.rs
+  git add executor/crates/executor-server/tests/integration_rest.rs
+  git commit -m "feat(executor): PR-C2 mainnet safety gate (allowlist + size cap)"
+
+  git add docs/HANDOFF-2026-05-05.md
+  git commit -m "docs: HANDOFF — PR-C2 完了"
+  ```
+- [ ] Push to develop or branch + PR (per branch strategy: pre-v1.0 direct push to develop is OK, but feature work for safety-critical change merits a PR for visibility).
+
+## Step 13: PR creation (--base develop)
+
+- [ ] `git push origin develop` (or feature branch).
+- [ ] If feature branch: `gh pr create --base develop --title "feat(executor): PR-C2 mainnet safety gate (allowlist + size cap)" --body ...`.
+- [ ] Wait for CI green; user reviews and merges.
+
+---
+
+## Acceptance gates
+
+- [ ] All tests pass: `cargo test --workspace`
+- [ ] No clippy warnings: `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+- [ ] CI script clean: `scripts/check_ci_local.sh`
+- [ ] `--mode real --base mainnet` with empty `--mainnet-allow-symbols` returns nonzero exit + clear error message (manual verification by user)
+- [ ] `--mode real --base mainnet --mainnet-allow-symbols ETH --mainnet-max-notional-usd 20` starts cleanly with safety gate logged
+- [ ] PR description clearly explains the 2-layer design, Gemini-flipped decisions, and the production deployment intent

--- a/docs/superpowers/specs/2026-05-05-pr-c2-symbol-allowlist-size-cap-design.md
+++ b/docs/superpowers/specs/2026-05-05-pr-c2-symbol-allowlist-size-cap-design.md
@@ -1,0 +1,454 @@
+# PR-C2: symbol allowlist + size cap (mainnet safety gate) 設計
+
+**作成日**: 2026-05-05
+**ブランチ**: `feat/pr-c2-mainnet-safety-gate` (実装時に作成)
+**親 spec**: `docs/superpowers/specs/2026-05-05-hl-mainnet-readonly-and-minimal-order-test-design.md` Stage C (production path 移行)
+**前提コード**: PR-C1 merged (`develop@2a5dc44`)
+**Gemini deep review**: 2026-05-05, `review_log:awei5shyz83tjs2lxpu3` (8 論点全クリア / Q3,Q4 で Claude 案を flip)
+
+## 1. 目的
+
+executor-server に **2 段の defense-in-depth gate** を入れ, mainnet 投入時の誤発注 (algo bug / 設定ミス) を
+構造的に防ぐ. これにより executor-server を放置運用できる状態を作る.
+
+具体的には:
+
+1. **CLI flag** `--mainnet-allow-symbols ETH,BTC` `--mainnet-max-notional-usd 20` を追加
+2. **Layer 1 (REST 入口)**: `POST /v1/exec` で symbol が allow-list 外 / 概算 notional が cap 超過 → 400 Bad Request
+3. **Layer 2 (BatchSender enqueue 直前)**: algo が動的生成した `OrderIntent` を gate でチェック, 違反は drop + ack に Err
+4. **mock mode は gate 全 skip** (CI 既存 145 tests 無影響)
+5. **mainnet で allow-list 空 = fatal error 起動拒否** (Gemini 指摘: warn は見落とされる)
+6. **`OrderOrCancel::Cancel` は gate を通さない** (緊急停止経路を阻害しないため)
+
+これにより:
+- algo がバグって ETH 以外 (HYPE / xyz:META / xyz:GOOGL etc.) に発注しようとしても server が拒否
+- 「Master EOA 既存ポジを絶対に触らない」契約が CLI flag だけで保証可能
+- production 投入時に `--mainnet-allow-symbols ETH --mainnet-max-notional-usd 20` で起動するだけで safe
+
+## 2. 非目的
+
+- baseline-diff guard 自動 emergency_stop (PR-C3)
+- emergency_stop multi-symbol live test + e2e live test (PR-C4)
+- 動的 (runtime) allow-list 変更 (Phase 4 以降)
+- mock mode への gate 適用 (CI 既存テストへの影響回避)
+- HL min notional / tick size の構造的検証 (HL 側 reject に委ねる; 別レイヤー)
+
+## 3. 制約と前提
+
+### 3.1 既存コード状況 (2026-05-05, PR-C1 merged 後)
+
+| 項目 | 現状 |
+|---|---|
+| `executor-server` `Args` | `--mode mock\|real` `--base mainnet\|testnet` `--bind` の 3 flag |
+| `BatchSender::enqueue(item: OrderOrCancel) -> Result<(), HlError>` | gate なし (素通し) |
+| `OrderRouter::supported()` | `["market", "passive", "twap", "market_make"]` |
+| `start_exec` handler | `validate_algorithm_name` の後すぐ `OrderRouter::build` → `tokio::spawn` |
+| `ServerState` | `app_state, hl_client, signer, batch_sender, batch_handle, registry` |
+| `OrderIntent` (PR-C1) | `cloid, symbol, side, px, sz, tif, reduce_only` (asset field は除去済) |
+| `Symbol` | `executor-core::symbol::Symbol` (`String`-based newtype, `as_str()`) |
+
+### 3.2 設計上の固定制約 (Gemini deep + ユーザー指示)
+
+- **Q3 採用**: `--mode real --base mainnet` かつ `--mainnet-allow-symbols=""` は **fatal error** で起動拒否
+- **Q4 採用**: `--mainnet-max-notional-usd` は `Option<u64>` (省略可能, 省略 = 上限なし)
+- **Q1 採用**: gate 配置は **選択肢 C** (`BatchSender` に `Option<Arc<dyn IntentChecker>>` を持たせる)
+- mock mode の gate disable は **`SafetyGate::disabled()` sentinel** で実装 (allow_symbols=None かつ max=None)
+- `OrderOrCancel::Cancel` は gate チェック対象外
+- `start_exec` の Layer 1 で notional 計算に best_bid を使う (rough fail-fast)
+- testnet mode でも gate は適用 (gate 自体のテスト場として活用)
+- error message に allowed symbol リストを含める (内部 API なので機密上問題なし)
+
+## 4. アーキテクチャ
+
+### 4.1 crate 配置とレイヤリング
+
+```
+executor-core    : OrderIntent / Symbol / ... (既存, 変更なし)
+executor-hl      : BatchSender + IntentChecker trait (新規 trait, 最小 4 行)
+                   + spawn_batch_sender_with_gate() 新設
+executor-server  : SafetyGate 構造体 (実装) + impl IntentChecker for SafetyGate
+                   + safety.rs (新規ファイル)
+                   + main.rs に CLI flag + 起動時 gate 構築
+                   + routes.rs::start_exec に Layer 1 gate
+```
+
+`IntentChecker` trait を `executor-hl` に置く理由: BatchSender が trait を呼ぶため.
+`SafetyGate` の実装は `executor-server` に置く (CLI flag 由来であり Wire format とは無関係).
+`OrderIntent` 自体は `executor-core` 由来なので, leaky にはならない.
+
+### 4.2 SafetyGate 構造体
+
+```rust
+// executor-server/src/safety.rs
+use std::collections::HashSet;
+use rust_decimal::Decimal;
+use executor_core::intent::OrderIntent;
+use executor_core::symbol::Symbol;
+use executor_hl::batch_sender::IntentChecker;
+
+#[derive(Debug, Clone)]
+pub struct SafetyGate {
+    /// `None` = gate disabled (mock mode). `Some(set)` = active allow-list.
+    pub allow_symbols: Option<HashSet<Symbol>>,
+    /// `None` = no notional cap. `Some(usd)` = cap.
+    pub max_notional_usd: Option<Decimal>,
+}
+
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum SafetyViolation {
+    #[error("symbol_not_allowed: symbol={symbol}, allowed={allowed:?}")]
+    SymbolNotAllowed { symbol: Symbol, allowed: Vec<Symbol> },
+    #[error("notional_exceeded: symbol={symbol}, notional={notional}, max={max}")]
+    NotionalExceeded { symbol: Symbol, notional: Decimal, max: Decimal },
+}
+
+impl SafetyGate {
+    pub fn disabled() -> Self;
+
+    /// Build from CLI args. Returns Err if mainnet+real+empty allow-list.
+    pub fn from_args(
+        allow_csv: &str,
+        max_usd: Option<u64>,
+        is_mainnet_real: bool,
+    ) -> Result<Self, anyhow::Error>;
+
+    /// Layer 1 (REST entry): rough fail-fast using a reference price.
+    /// `ref_px = None` skips the notional check (book unavailable).
+    pub fn check_request(
+        &self,
+        symbol: &Symbol,
+        target_size: Decimal,
+        ref_px: Option<Decimal>,
+    ) -> Result<(), SafetyViolation>;
+
+    /// Layer 2 (enqueue): strict check using actual order px.
+    pub fn check_intent(&self, intent: &OrderIntent) -> Result<(), SafetyViolation>;
+}
+
+impl IntentChecker for SafetyGate {
+    fn check_place(&self, o: &OrderIntent) -> Result<(), String> {
+        self.check_intent(o).map_err(|v| v.to_string())
+    }
+}
+```
+
+### 4.3 IntentChecker trait
+
+```rust
+// executor-hl/src/intent_checker.rs (新規ファイル, ~10 LOC)
+use executor_core::intent::OrderIntent;
+
+pub trait IntentChecker: std::fmt::Debug + Send + Sync + 'static {
+    /// Return `Err(reason)` to reject the place. `Ok(())` to allow.
+    fn check_place(&self, intent: &OrderIntent) -> Result<(), String>;
+}
+```
+
+### 4.4 BatchSender 改修
+
+```rust
+// executor-hl/src/batch_sender.rs
+
+#[derive(Clone)]
+pub struct BatchSender {
+    tx: mpsc::Sender<Envelope>,
+    /// `None` = gate disabled. Set via spawn_batch_sender_with_gate.
+    gate: Option<Arc<dyn IntentChecker>>,
+}
+
+impl BatchSender {
+    pub fn enqueue(&self, item: OrderOrCancel) -> Result<(), HlError> {
+        // Layer 2 gate
+        if let (Some(gate), OrderOrCancel::Place(intent)) = (&self.gate, &item) {
+            if let Err(reason) = gate.check_place(intent) {
+                tracing::error!(reason, ?intent.cloid, ?intent.symbol, "safety_gate: drop place");
+                return Err(HlError::ActionFormat(format!("safety_gate: {reason}")));
+            }
+        }
+        self.tx.try_send(Envelope { item, ack: None })
+            .map_err(|e| HlError::Network(format!("batch enqueue: {e}")))
+    }
+
+    // enqueue_with_ack も同じ gate を通す
+}
+
+pub fn spawn_batch_sender<C>(client: Arc<C>, cfg: BatchSenderConfig) -> (BatchSender, BatchSenderHandle)
+where C: HlClient + 'static
+{
+    spawn_batch_sender_with_gate(client, None, cfg)
+}
+
+pub fn spawn_batch_sender_with_gate<C>(
+    client: Arc<C>,
+    gate: Option<Arc<dyn IntentChecker>>,
+    cfg: BatchSenderConfig,
+) -> (BatchSender, BatchSenderHandle)
+where C: HlClient + 'static
+{
+    let (tx, rx) = mpsc::channel(1024);
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    let join = tokio::spawn(flusher_loop(client, rx, cfg, shutdown_rx));
+    (
+        BatchSender { tx, gate },
+        BatchSenderHandle { join, shutdown: shutdown_tx },
+    )
+}
+```
+
+`flusher_loop` 内部の `flush_now` は変更不要 (gate は enqueue 時にすでに通過している).
+
+### 4.5 main.rs CLI flag 追加
+
+```rust
+#[derive(Parser, Debug)]
+struct Args {
+    #[arg(long, default_value = "mock")]
+    mode: Mode,
+    #[arg(long, default_value = "mainnet")]
+    base: Base,
+    #[arg(long, env = "EXECUTOR_BIND", default_value = "0.0.0.0:8085")]
+    bind: String,
+
+    /// Mainnet allow-list of symbols. Comma-separated (e.g. "ETH,BTC").
+    /// REQUIRED for `--mode real --base mainnet`. Use `*` for explicit allow-all.
+    #[arg(long, env = "EXECUTOR_MAINNET_ALLOW_SYMBOLS", default_value = "")]
+    mainnet_allow_symbols: String,
+
+    /// Mainnet hard cap on per-order notional (USD).
+    /// Omit for no cap (NOT recommended for prod).
+    #[arg(long, env = "EXECUTOR_MAINNET_MAX_NOTIONAL_USD")]
+    mainnet_max_notional_usd: Option<u64>,
+}
+```
+
+main 処理:
+```rust
+let is_mainnet_real = matches!(args.mode, Mode::Real) && matches!(args.base, Base::Mainnet);
+
+let safety = match args.mode {
+    Mode::Mock => Arc::new(SafetyGate::disabled()),
+    Mode::Real => Arc::new(SafetyGate::from_args(
+        &args.mainnet_allow_symbols,
+        args.mainnet_max_notional_usd,
+        is_mainnet_real,
+    ).context("safety gate construction failed")?),
+};
+
+tracing::info!(
+    allow_symbols = ?safety.allow_symbols,
+    max_notional_usd = ?safety.max_notional_usd,
+    "safety gate constructed",
+);
+
+let gate_dyn: Option<Arc<dyn IntentChecker>> = match args.mode {
+    Mode::Mock => None,
+    Mode::Real => Some(safety.clone() as Arc<dyn IntentChecker>),
+};
+
+let (batch_sender, batch_handle) = spawn_batch_sender_with_gate(
+    /* hl_client */ ..., gate_dyn, batch_cfg,
+);
+```
+
+`SafetyGate::from_args`:
+```rust
+pub fn from_args(
+    allow_csv: &str,
+    max_usd: Option<u64>,
+    is_mainnet_real: bool,
+) -> anyhow::Result<Self> {
+    let allow_symbols = if allow_csv.trim().is_empty() {
+        if is_mainnet_real {
+            anyhow::bail!(
+                "--mainnet-allow-symbols is required for --mode real --base mainnet. \
+                 Use '*' to explicitly allow all (NOT recommended)."
+            );
+        }
+        Some(HashSet::new())  // testnet+real で空指定: 何も通さない (= 厳しい側)
+    } else if allow_csv.trim() == "*" {
+        None  // 明示 allow-all (Symbol チェックを skip)
+    } else {
+        Some(allow_csv.split(',')
+            .map(|s| Symbol::new(s.trim().to_string()))
+            .collect())
+    };
+    let max_notional_usd = max_usd.map(Decimal::from);
+    Ok(Self { allow_symbols, max_notional_usd })
+}
+```
+
+注: `SafetyGate::disabled()` は `allow_symbols = None, max_notional_usd = None`.
+`*` allow-all も同じ意味の `None`. distinction は不要 (両者 effect 同じ).
+testnet+real で空指定は `Some(empty)` = 全 reject. 「testnet で gate 体感テスト」のため.
+
+### 4.6 ServerState への追加
+
+```rust
+pub struct ServerState {
+    pub app_state: Arc<AppState>,
+    pub hl_client: Arc<dyn HlClient>,
+    pub signer: Arc<dyn Signer>,
+    pub batch_sender: BatchSender,
+    pub batch_handle: tokio::sync::Mutex<Option<BatchSenderHandle>>,
+    pub registry: ExecutionRegistry,
+    pub safety: Arc<SafetyGate>,    // 新規
+}
+
+impl ServerState {
+    pub fn new(
+        app_state: Arc<AppState>,
+        hl_client: Arc<dyn HlClient>,
+        signer: Arc<dyn Signer>,
+        batch_sender: BatchSender,
+        batch_handle: BatchSenderHandle,
+        safety: Arc<SafetyGate>,    // 新規
+    ) -> Self { ... }
+}
+```
+
+### 4.7 routes.rs::start_exec の Layer 1
+
+```rust
+pub async fn start_exec(
+    State(s): State<Arc<ServerState>>,
+    Json(req): Json<StartExecRequest>,
+) -> Result<Json<StartExecResponse>, ServerError> {
+    validate_algorithm_name(&req.algorithm)?;
+
+    let symbol = Symbol::new(req.symbol.clone());
+    let ref_px = {
+        let book_g = s.app_state.book.read().await;
+        book_g.get(&symbol).and_then(|b| b.best_bid())
+    };
+    s.safety
+        .check_request(&symbol, req.target_size, ref_px)
+        .map_err(|v| ServerError::BadRequest(format!("safety_gate: {v}")))?;
+
+    let mut algo = OrderRouter::build(&req.algorithm)?;
+    // ... 既存処理
+}
+```
+
+`SafetyGate::check_request`:
+```rust
+pub fn check_request(&self, symbol: &Symbol, target_size: Decimal, ref_px: Option<Decimal>)
+    -> Result<(), SafetyViolation>
+{
+    if let Some(allowed) = &self.allow_symbols {
+        if !allowed.contains(symbol) {
+            return Err(SafetyViolation::SymbolNotAllowed {
+                symbol: symbol.clone(),
+                allowed: allowed.iter().cloned().collect(),
+            });
+        }
+    }
+    if let (Some(max), Some(px)) = (self.max_notional_usd, ref_px) {
+        let notional = px * target_size;
+        if notional > max {
+            return Err(SafetyViolation::NotionalExceeded {
+                symbol: symbol.clone(),
+                notional,
+                max,
+            });
+        }
+    }
+    Ok(())
+}
+```
+
+`SafetyGate::check_intent` (Layer 2):
+```rust
+pub fn check_intent(&self, o: &OrderIntent) -> Result<(), SafetyViolation> {
+    if let Some(allowed) = &self.allow_symbols {
+        if !allowed.contains(&o.symbol) {
+            return Err(SafetyViolation::SymbolNotAllowed { ... });
+        }
+    }
+    if let Some(max) = self.max_notional_usd {
+        let notional = o.px * o.sz;
+        if notional > max {
+            return Err(SafetyViolation::NotionalExceeded { ... });
+        }
+    }
+    Ok(())
+}
+```
+
+## 5. テスト計画
+
+### 5.1 SafetyGate unit tests (`safety.rs::tests`, ~8 件)
+
+1. `disabled_gate_passes_everything`: `disabled()` で `check_request`, `check_intent` 両方 OK
+2. `allow_list_rejects_non_member`: `{ETH,BTC}` で symbol=XRP → `SymbolNotAllowed`
+3. `allow_list_accepts_member`: 同上で symbol=ETH → Ok
+4. `notional_cap_rejects_over`: max=$10 で px=$2400 sz=0.005 (=$12) → `NotionalExceeded`
+5. `notional_cap_accepts_under`: 上記で sz=0.004 (=$9.6) → Ok
+6. `from_args_mainnet_empty_fatal`: `from_args("", None, true)` → Err
+7. `from_args_mainnet_star_allow_all`: `from_args("*", None, true)` → Ok, allow_symbols=None
+8. `from_args_csv_parses`: `from_args("ETH, BTC", Some(20), true)` → Ok, allow_symbols={ETH,BTC}, max=20
+
+### 5.2 BatchSender Layer 2 tests (`batch_sender.rs::tests`, ~3 件)
+
+1. `enqueue_with_gate_rejects_violation`: `IntentChecker` mock が `Err("test")` 返す → `enqueue` が `HlError::ActionFormat`
+2. `enqueue_with_gate_passes_ok`: mock が `Ok(())` → enqueue 成功 → flush で実 client 呼び出し
+3. `enqueue_cancel_skips_gate`: gate あっても `OrderOrCancel::Cancel` は通る
+
+### 5.3 Integration tests (`integration_rest.rs`, ~3 件)
+
+`build_state_with_seed()` をオーバーロード or `build_state_with_safety(SafetyGate)` 追加:
+
+1. `start_exec_symbol_not_allowed_400`: `SafetyGate { allow={BTC} }` で `symbol=ETH` start → 400
+2. `start_exec_notional_exceeded_400`: `SafetyGate { max=$10 }` + 仕込み book で `target_size=0.5` → 400
+3. `start_exec_within_caps_200`: 同上で `target_size=0.0001` → 200
+
+### 5.4 既存テスト無影響性
+
+`build_state_with_seed()` は `Arc::new(SafetyGate::disabled())` を ServerState::new に渡す形に修正.
+既存 10 tests は全 pass のまま.
+
+## 6. 実装順序 (Plan で詳細化)
+
+1. `executor-hl/src/intent_checker.rs` 新規 + `lib.rs` で `pub mod intent_checker;`
+2. `BatchSender` に `gate` field 追加 + `spawn_batch_sender_with_gate` 新設 + 既存 `spawn_batch_sender` を wrapper 化
+3. `BatchSender::enqueue` / `enqueue_with_ack` で gate チェック (Place のみ)
+4. `executor-server/src/safety.rs` 新規 (`SafetyGate`, `SafetyViolation`, `IntentChecker` impl)
+5. `ServerState::new` に `safety: Arc<SafetyGate>` 追加
+6. `routes.rs::start_exec` に Layer 1 gate 注入
+7. `main.rs` に CLI flag + `from_args` 起動シーケンス + `spawn_batch_sender_with_gate` 呼び替え
+8. `integration_rest.rs::build_state_with_seed` を `SafetyGate::disabled()` 渡しに修正
+9. SafetyGate unit tests 追加 (8 件)
+10. BatchSender Layer 2 tests 追加 (3 件)
+11. Integration tests 追加 (3 件)
+12. `cargo fmt && cargo clippy -D warnings && cargo test --workspace` 全 pass 確認
+13. `scripts/check_ci_local.sh` green
+14. HANDOFF doc 追記 / commit / push / PR (--base develop)
+
+## 7. リスクとフォールバック
+
+| リスク | 影響 | 対策 |
+|---|---|---|
+| `Arc<dyn IntentChecker>` の vtable オーバーヘッド | enqueue ホットパスで微小 | mock mode は `gate=None` で if-let-else 即パス. real mode は ETH 1 symbol だけなので無視可能 |
+| `BatchSender::clone` で `Arc<dyn ...>` の Arc::clone コスト | enqueue 1 回 / order | 同上 |
+| trait object の Debug 制約 | `BatchSender: Debug` derive 失敗 | manual `Debug` 実装で `gate` field を `gate: bool` 表記 |
+| testnet で `from_args("", ...)` を allow-all と勘違い | testnet で全 reject になる | doc string に明記 + 起動 log で `allow_symbols=Some({})` 表示 |
+| `SafetyGate::check_intent` で `o.px * o.sz` が overflow | rust_decimal の限界 (96-bit mantissa) | HL の px/sz はこの limit 以内 (実機検証済 PR-B2b) |
+
+## 8. 受入条件
+
+- [ ] `cargo build --workspace` clean
+- [ ] `cargo test --workspace` 全 pass (既存 145 + 新規 ~14 = ~159 件以上)
+- [ ] `cargo fmt --all -- --check` clean
+- [ ] `cargo clippy --all-targets --all-features -- -D warnings` clean
+- [ ] `scripts/check_ci_local.sh` green
+- [ ] `--mode real --base mainnet --mainnet-allow-symbols ""` で **fatal error 起動拒否** を log で確認
+- [ ] `--mode real --base mainnet --mainnet-allow-symbols ETH --mainnet-max-notional-usd 20` で `safety gate constructed allow_symbols=Some({ETH}) max=Some(20)` log
+- [ ] curl `start_exec(symbol=ETH, target_size=0.005)` 実機で 200 + place 発火
+- [ ] curl `start_exec(symbol=BTC, target_size=0.005)` 実機で 400 + log
+- [ ] CI green / PR merge 待ち
+
+## 9. 関連 PR / Issue
+
+- 親 spec: `2026-05-05-hl-mainnet-readonly-and-minimal-order-test-design.md` Stage C
+- 前 PR: PR-C1 (`develop@2a5dc44`)
+- 次 PR: PR-C3 (baseline-diff guard 自動 emergency_stop)
+- 最後 PR: PR-C4 (multi-symbol live test + e2e)

--- a/executor/crates/executor-hl/src/batch_sender.rs
+++ b/executor/crates/executor-hl/src/batch_sender.rs
@@ -20,6 +20,7 @@ use executor_core::intent::{CancelIntent, OrderIntent};
 
 use crate::errors::HlError;
 use crate::hl_client::HlClient;
+use crate::intent_checker::IntentChecker;
 
 /// Either an order to place or a cancel to send.
 #[derive(Debug, Clone)]
@@ -45,9 +46,21 @@ impl Default for BatchSenderConfig {
 }
 
 /// Sender side: hand to algorithms.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct BatchSender {
     tx: mpsc::Sender<Envelope>,
+    /// `None` = gate disabled (mock mode / pre-PR-C2 path).
+    /// `Some(...)` = consulted before enqueueing each `OrderOrCancel::Place`;
+    /// `OrderOrCancel::Cancel` always bypasses the gate (emergency_stop must work).
+    gate: Option<Arc<dyn IntentChecker>>,
+}
+
+impl std::fmt::Debug for BatchSender {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BatchSender")
+            .field("gate", &self.gate.is_some())
+            .finish_non_exhaustive()
+    }
 }
 
 #[derive(Debug)]
@@ -59,6 +72,9 @@ struct Envelope {
 
 impl BatchSender {
     pub fn enqueue(&self, item: OrderOrCancel) -> Result<(), HlError> {
+        if let Some(reason) = self.gate_reject_reason(&item) {
+            return Err(HlError::ActionFormat(format!("safety_gate: {reason}")));
+        }
         self.tx
             .try_send(Envelope { item, ack: None })
             .map_err(|e| HlError::Network(format!("batch enqueue: {e}")))
@@ -69,6 +85,9 @@ impl BatchSender {
         &self,
         item: OrderOrCancel,
     ) -> Result<oneshot::Receiver<Result<(), HlError>>, HlError> {
+        if let Some(reason) = self.gate_reject_reason(&item) {
+            return Err(HlError::ActionFormat(format!("safety_gate: {reason}")));
+        }
         let (ack_tx, ack_rx) = oneshot::channel();
         self.tx
             .send(Envelope {
@@ -79,6 +98,30 @@ impl BatchSender {
             .map_err(|e| HlError::Network(format!("batch enqueue: {e}")))?;
         Ok(ack_rx)
     }
+
+    /// Gate-only check: returns `Some(reason)` when the place should be
+    /// rejected, `None` when it passes (or is a Cancel / no gate configured).
+    /// Logs the rejection at error level so operators can see safety drops
+    /// without having to thread the BatchSender's tracing context to the call site.
+    fn gate_reject_reason(&self, item: &OrderOrCancel) -> Option<String> {
+        let gate = self.gate.as_ref()?;
+        let intent = match item {
+            OrderOrCancel::Place(o) => o,
+            OrderOrCancel::Cancel(_) => return None,
+        };
+        match gate.check_place(intent) {
+            Ok(()) => None,
+            Err(reason) => {
+                tracing::error!(
+                    reason = %reason,
+                    cloid = ?intent.cloid,
+                    symbol = %intent.symbol,
+                    "safety_gate: drop place"
+                );
+                Some(reason)
+            }
+        }
+    }
 }
 
 /// Spawned flusher task handle; await on this to know when it has shut down.
@@ -88,10 +131,25 @@ pub struct BatchSenderHandle {
     pub shutdown: oneshot::Sender<()>,
 }
 
-/// Spawn a BatchSender + flusher pair. Returns the sender (clone for each algo)
-/// and a handle to await/cleanly stop the flusher.
+/// Spawn a BatchSender + flusher pair without a safety gate. Equivalent to
+/// `spawn_batch_sender_with_gate(client, None, cfg)`.
 pub fn spawn_batch_sender<C>(
     client: Arc<C>,
+    cfg: BatchSenderConfig,
+) -> (BatchSender, BatchSenderHandle)
+where
+    C: HlClient + 'static,
+{
+    spawn_batch_sender_with_gate(client, None, cfg)
+}
+
+/// Spawn a BatchSender + flusher pair with an optional `IntentChecker` gate.
+/// PR-C2 (Gemini deep, 2026-05-05): real-mode startup wires this up so every
+/// `OrderOrCancel::Place` is checked at enqueue time. `OrderOrCancel::Cancel`
+/// always bypasses the gate so `emergency_stop` keeps working.
+pub fn spawn_batch_sender_with_gate<C>(
+    client: Arc<C>,
+    gate: Option<Arc<dyn IntentChecker>>,
     cfg: BatchSenderConfig,
 ) -> (BatchSender, BatchSenderHandle)
 where
@@ -101,7 +159,7 @@ where
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
     let join = tokio::spawn(flusher_loop(client, rx, cfg, shutdown_rx));
     (
-        BatchSender { tx },
+        BatchSender { tx, gate },
         BatchSenderHandle {
             join,
             shutdown: shutdown_tx,
@@ -299,5 +357,96 @@ mod tests {
         let cancelled = mock.cancelled_calls();
         assert!(!placed.is_empty());
         assert!(!cancelled.is_empty());
+    }
+
+    // ---- PR-C2: gate tests ----
+
+    #[derive(Debug)]
+    struct AllowAll;
+
+    impl IntentChecker for AllowAll {
+        fn check_place(&self, _: &OrderIntent) -> Result<(), String> {
+            Ok(())
+        }
+    }
+
+    #[derive(Debug)]
+    struct RejectAll;
+
+    impl IntentChecker for RejectAll {
+        fn check_place(&self, _: &OrderIntent) -> Result<(), String> {
+            Err("blocked by test".into())
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn enqueue_with_gate_rejects_violation() {
+        let mock = Arc::new(MockHlClient::new());
+        let (sender, handle) = spawn_batch_sender_with_gate(
+            mock.clone(),
+            Some(Arc::new(RejectAll) as Arc<dyn IntentChecker>),
+            BatchSenderConfig::default(),
+        );
+        let res = sender.enqueue(OrderOrCancel::Place(order(Cloid::new())));
+        let err = res.expect_err("gate must reject");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("safety_gate") && msg.contains("blocked by test"),
+            "unexpected error: {msg}"
+        );
+        // No flush should happen — buffer is empty.
+        tokio::time::advance(Duration::from_millis(150)).await;
+        let _ = handle.shutdown.send(());
+        let _ = handle.join.await;
+        assert!(
+            mock.placed_calls().is_empty(),
+            "rejected orders must never reach client"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn enqueue_with_gate_passes_ok() {
+        let mock = Arc::new(MockHlClient::new());
+        let (sender, handle) = spawn_batch_sender_with_gate(
+            mock.clone(),
+            Some(Arc::new(AllowAll) as Arc<dyn IntentChecker>),
+            BatchSenderConfig::default(),
+        );
+        sender
+            .enqueue(OrderOrCancel::Place(order(Cloid::new())))
+            .expect("AllowAll must pass");
+        tokio::time::advance(Duration::from_millis(150)).await;
+        let _ = handle.shutdown.send(());
+        let _ = handle.join.await;
+        let calls = mock.placed_calls();
+        assert_eq!(
+            calls.iter().map(|v| v.len()).sum::<usize>(),
+            1,
+            "the single allowed order must reach client"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn enqueue_cancel_skips_gate() {
+        let mock = Arc::new(MockHlClient::new());
+        let (sender, handle) = spawn_batch_sender_with_gate(
+            mock.clone(),
+            Some(Arc::new(RejectAll) as Arc<dyn IntentChecker>),
+            BatchSenderConfig::default(),
+        );
+        sender
+            .enqueue(OrderOrCancel::Cancel(CancelIntent {
+                symbol: Symbol::new("BTC"),
+                by_cloid: Some(Cloid::new()),
+                by_oid: None,
+            }))
+            .expect("Cancel must pass even with RejectAll gate");
+        tokio::time::advance(Duration::from_millis(150)).await;
+        let _ = handle.shutdown.send(());
+        let _ = handle.join.await;
+        assert!(
+            !mock.cancelled_calls().is_empty(),
+            "cancel must reach client unchanged"
+        );
     }
 }

--- a/executor/crates/executor-hl/src/intent_checker.rs
+++ b/executor/crates/executor-hl/src/intent_checker.rs
@@ -1,0 +1,13 @@
+//! Pluggable pre-flight check for `OrderIntent` placements.
+//!
+//! `BatchSender` consults a gate before enqueueing an `OrderOrCancel::Place`.
+//! `OrderOrCancel::Cancel` is never gated — emergency_stop must always work.
+//! The concrete check (e.g. symbol allow-list + size cap) lives in
+//! `executor-server::safety::SafetyGate` and impls this trait.
+
+use executor_core::intent::OrderIntent;
+
+pub trait IntentChecker: std::fmt::Debug + Send + Sync + 'static {
+    /// Inspect the intent. Return `Err(reason)` to drop, `Ok(())` to allow.
+    fn check_place(&self, intent: &OrderIntent) -> Result<(), String>;
+}

--- a/executor/crates/executor-hl/src/lib.rs
+++ b/executor/crates/executor-hl/src/lib.rs
@@ -17,6 +17,7 @@ pub mod batch_sender;
 pub mod eip712;
 pub mod errors;
 pub mod hl_client;
+pub mod intent_checker;
 pub mod meta;
 pub mod rate_limiter;
 pub mod signer;
@@ -29,6 +30,7 @@ pub use hl_client::{
     AccountStateSnapshot, HlClient, HlConfig, HlOpenOrder, MockHlClient, OrderResponse,
     RealHlClient, Role,
 };
+pub use intent_checker::IntentChecker;
 pub use rate_limiter::TokenBucket;
 pub use signer::{Eip712AgentSigner, MockSigner, Signature, Signer};
 pub use ws_state::WsStateManager;

--- a/executor/crates/executor-server/src/lib.rs
+++ b/executor/crates/executor-server/src/lib.rs
@@ -20,12 +20,14 @@ pub mod error;
 pub mod registry;
 pub mod router;
 pub mod routes;
+pub mod safety;
 pub mod state;
 pub mod ws;
 
 pub use error::ServerError;
 pub use registry::{ExecutionHandle, ExecutionRegistry, ExecutionStatus};
 pub use router::OrderRouter;
+pub use safety::{SafetyGate, SafetyViolation};
 pub use state::ServerState;
 
 use std::sync::Arc;

--- a/executor/crates/executor-server/src/main.rs
+++ b/executor/crates/executor-server/src/main.rs
@@ -19,11 +19,12 @@ use std::time::Duration;
 use anyhow::Context;
 use clap::{Parser, ValueEnum};
 use executor_core::state::AppState;
-use executor_hl::batch_sender::{spawn_batch_sender, BatchSenderConfig};
+use executor_hl::batch_sender::{spawn_batch_sender_with_gate, BatchSenderConfig};
 use executor_hl::hl_client::{HlClient, HlConfig, MockHlClient, RealHlClient};
 use executor_hl::meta::MetaCache;
 use executor_hl::signer::{Eip712AgentSigner, MockSigner, Signer};
-use executor_server::{build_app, ServerState};
+use executor_hl::IntentChecker;
+use executor_server::{build_app, SafetyGate, ServerState};
 use secrecy::SecretString;
 
 #[derive(Parser, Debug)]
@@ -40,6 +41,16 @@ struct Args {
     /// Bind address (host:port).
     #[arg(long, env = "EXECUTOR_BIND", default_value = "0.0.0.0:8085")]
     bind: String,
+
+    /// Mainnet allow-list of symbols (comma-separated, e.g. "ETH,BTC").
+    /// REQUIRED for `--mode real --base mainnet`.
+    /// Use `*` to explicitly allow all (NOT recommended for production).
+    #[arg(long, env = "EXECUTOR_MAINNET_ALLOW_SYMBOLS", default_value = "")]
+    mainnet_allow_symbols: String,
+
+    /// Per-order USD notional cap. Omit for no cap (NOT recommended for production).
+    #[arg(long, env = "EXECUTOR_MAINNET_MAX_NOTIONAL_USD")]
+    mainnet_max_notional_usd: Option<u64>,
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum)]
@@ -74,9 +85,28 @@ async fn main() -> anyhow::Result<()> {
         max_batch_size: 50,
     };
 
-    // `spawn_batch_sender<C>` requires a concrete sized `C: HlClient`, so we
-    // build the BatchSender inside each match arm where the type is known and
-    // erase to `Arc<dyn HlClient>` only for `ServerState::new`.
+    // PR-C2: build the safety gate. In real mode this validates the CLI args
+    // (mainnet+empty allow-list is a fatal error per Gemini deep, 2026-05-05).
+    let is_mainnet_real = matches!(args.mode, Mode::Real) && matches!(args.base, Base::Mainnet);
+    let safety = Arc::new(match args.mode {
+        Mode::Mock => SafetyGate::disabled(),
+        Mode::Real => SafetyGate::from_args(
+            &args.mainnet_allow_symbols,
+            args.mainnet_max_notional_usd,
+            is_mainnet_real,
+        )
+        .context("safety gate construction failed")?,
+    });
+    tracing::info!(
+        mode = ?args.mode,
+        allow_symbols = ?safety.allow_symbols,
+        max_notional_usd = ?safety.max_notional_usd,
+        "safety gate constructed",
+    );
+
+    // `spawn_batch_sender_with_gate<C>` requires a concrete sized `C: HlClient`,
+    // so we build the BatchSender inside each match arm where the type is known
+    // and erase to `Arc<dyn HlClient>` only for `ServerState::new`.
     let (hl_client, signer, batch_sender, batch_handle): (
         Arc<dyn HlClient>,
         Arc<dyn Signer>,
@@ -87,7 +117,8 @@ async fn main() -> anyhow::Result<()> {
             tracing::info!("starting in mock mode");
             let mock_hl = Arc::new(MockHlClient::new());
             let mock_signer: Arc<dyn Signer> = Arc::new(MockSigner::new());
-            let (batch_sender, batch_handle) = spawn_batch_sender(mock_hl.clone(), batch_cfg);
+            let (batch_sender, batch_handle) =
+                spawn_batch_sender_with_gate(mock_hl.clone(), None, batch_cfg);
             let hl_dyn: Arc<dyn HlClient> = mock_hl;
             (hl_dyn, mock_signer, batch_sender, batch_handle)
         }
@@ -112,7 +143,9 @@ async fn main() -> anyhow::Result<()> {
             );
             tracing::info!(symbols = meta.len(), "MetaCache built (default dex)");
             let real_client = Arc::new(bootstrap.with_meta(meta));
-            let (batch_sender, batch_handle) = spawn_batch_sender(real_client.clone(), batch_cfg);
+            let gate_dyn: Arc<dyn IntentChecker> = safety.clone();
+            let (batch_sender, batch_handle) =
+                spawn_batch_sender_with_gate(real_client.clone(), Some(gate_dyn), batch_cfg);
             let hl_dyn: Arc<dyn HlClient> = real_client;
             (hl_dyn, signer, batch_sender, batch_handle)
         }
@@ -124,6 +157,7 @@ async fn main() -> anyhow::Result<()> {
         signer,
         batch_sender,
         batch_handle,
+        safety,
     ));
 
     let app = build_app(state);

--- a/executor/crates/executor-server/src/routes.rs
+++ b/executor/crates/executor-server/src/routes.rs
@@ -96,6 +96,19 @@ pub async fn start_exec(
     Json(req): Json<StartExecRequest>,
 ) -> Result<Json<StartExecResponse>, ServerError> {
     validate_algorithm_name(&req.algorithm)?;
+
+    // PR-C2 Layer 1 (REST entry): symbol allow-list + rough notional cap using
+    // book.best_bid as the reference price. Strict per-order check happens at
+    // BatchSender enqueue time (Layer 2).
+    let symbol = Symbol::new(req.symbol.clone());
+    let ref_px = {
+        let book_g = s.app_state.book.read().await;
+        book_g.get(&symbol).and_then(|b| b.best_bid())
+    };
+    s.safety
+        .check_request(&symbol, req.target_size, ref_px)
+        .map_err(|v| ServerError::BadRequest(format!("safety_gate: {v}")))?;
+
     let mut algo = OrderRouter::build(&req.algorithm)?;
     let exec_id = ExecutionId::new();
 
@@ -111,7 +124,6 @@ pub async fn start_exec(
         }
     });
 
-    let symbol = Symbol::new(req.symbol);
     let ctx = ExecutionContext {
         exec_id,
         symbol,

--- a/executor/crates/executor-server/src/safety.rs
+++ b/executor/crates/executor-server/src/safety.rs
@@ -1,0 +1,307 @@
+//! Mainnet safety gate: symbol allow-list + per-order USD notional cap.
+//!
+//! Wires into the BatchSender via the `IntentChecker` trait at startup.
+//! Mock mode constructs a `disabled()` gate which short-circuits all checks.
+//! Real mode requires `--mainnet-allow-symbols` to be set when targeting
+//! mainnet; an empty value makes startup fatal (Gemini deep, 2026-05-05:
+//! "warn ログは見落とされる. 金融系では明示 opt-in を要求する").
+//!
+//! Two layers fire on a place:
+//! - **Layer 1** at `POST /v1/exec` via [`SafetyGate::check_request`] using
+//!   `book.best_bid` as a rough reference price.
+//! - **Layer 2** at [`executor_hl::BatchSender::enqueue`] via
+//!   [`SafetyGate::check_intent`] using the order's actual `px`.
+//!
+//! `OrderOrCancel::Cancel` always bypasses the gate so emergency_stop works.
+
+use std::collections::HashSet;
+
+use rust_decimal::Decimal;
+use thiserror::Error;
+
+use executor_core::intent::OrderIntent;
+use executor_core::symbol::Symbol;
+use executor_hl::IntentChecker;
+
+#[derive(Debug, Clone)]
+pub struct SafetyGate {
+    /// `None` = no symbol allow-list (everything passes).
+    /// `Some(set)` = only symbols in the set are allowed.
+    pub allow_symbols: Option<HashSet<Symbol>>,
+    /// `None` = no notional cap. `Some(usd)` = max per-order notional (USD).
+    pub max_notional_usd: Option<Decimal>,
+}
+
+#[derive(Debug, Clone, Error)]
+pub enum SafetyViolation {
+    #[error("symbol_not_allowed: symbol={symbol}, allowed={allowed:?}")]
+    SymbolNotAllowed {
+        symbol: Symbol,
+        allowed: Vec<Symbol>,
+    },
+    #[error("notional_exceeded: symbol={symbol}, notional={notional}, max={max}")]
+    NotionalExceeded {
+        symbol: Symbol,
+        notional: Decimal,
+        max: Decimal,
+    },
+}
+
+impl SafetyGate {
+    /// Mock mode / explicit allow-all: every request passes.
+    pub fn disabled() -> Self {
+        Self {
+            allow_symbols: None,
+            max_notional_usd: None,
+        }
+    }
+
+    /// Build from CLI args.
+    ///
+    /// `is_mainnet_real = (mode == real && base == mainnet)`. When that flag is
+    /// `true` and `allow_csv` is empty, this returns an error so the binary
+    /// refuses to start. The wildcard `"*"` is the explicit opt-in to allow-all.
+    pub fn from_args(
+        allow_csv: &str,
+        max_usd: Option<u64>,
+        is_mainnet_real: bool,
+    ) -> anyhow::Result<Self> {
+        let trimmed = allow_csv.trim();
+        let allow_symbols = if trimmed.is_empty() {
+            if is_mainnet_real {
+                anyhow::bail!(
+                    "--mainnet-allow-symbols is required for --mode real --base mainnet. \
+                     Use '*' to explicitly allow-all (NOT recommended for production)."
+                );
+            }
+            // Non-mainnet-real with empty CSV: keep as Some(empty) so the gate
+            // can still be exercised on testnet (rejects everything).
+            Some(HashSet::new())
+        } else if trimmed == "*" {
+            None
+        } else {
+            Some(
+                trimmed
+                    .split(',')
+                    .map(|s| Symbol::new(s.trim().to_string()))
+                    .filter(|s| !s.as_str().is_empty())
+                    .collect(),
+            )
+        };
+        Ok(Self {
+            allow_symbols,
+            max_notional_usd: max_usd.map(Decimal::from),
+        })
+    }
+
+    /// Layer 1: REST-entry rough check using a reference price (best_bid).
+    /// `ref_px = None` skips the notional check (no book yet) — the strict
+    /// check happens at [`Self::check_intent`] anyway.
+    pub fn check_request(
+        &self,
+        symbol: &Symbol,
+        target_size: Decimal,
+        ref_px: Option<Decimal>,
+    ) -> Result<(), SafetyViolation> {
+        if let Some(allowed) = &self.allow_symbols {
+            if !allowed.contains(symbol) {
+                return Err(SafetyViolation::SymbolNotAllowed {
+                    symbol: symbol.clone(),
+                    allowed: allowed.iter().cloned().collect(),
+                });
+            }
+        }
+        if let (Some(max), Some(px)) = (self.max_notional_usd, ref_px) {
+            let notional = px * target_size;
+            if notional > max {
+                return Err(SafetyViolation::NotionalExceeded {
+                    symbol: symbol.clone(),
+                    notional,
+                    max,
+                });
+            }
+        }
+        Ok(())
+    }
+
+    /// Layer 2: enqueue-time strict check using the order's actual px.
+    pub fn check_intent(&self, o: &OrderIntent) -> Result<(), SafetyViolation> {
+        if let Some(allowed) = &self.allow_symbols {
+            if !allowed.contains(&o.symbol) {
+                return Err(SafetyViolation::SymbolNotAllowed {
+                    symbol: o.symbol.clone(),
+                    allowed: allowed.iter().cloned().collect(),
+                });
+            }
+        }
+        if let Some(max) = self.max_notional_usd {
+            let notional = o.px * o.sz;
+            if notional > max {
+                return Err(SafetyViolation::NotionalExceeded {
+                    symbol: o.symbol.clone(),
+                    notional,
+                    max,
+                });
+            }
+        }
+        Ok(())
+    }
+}
+
+impl IntentChecker for SafetyGate {
+    fn check_place(&self, intent: &OrderIntent) -> Result<(), String> {
+        self.check_intent(intent).map_err(|v| v.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+
+    use super::*;
+    use executor_core::cloid::Cloid;
+    use executor_core::types::{Side, Tif};
+    use rust_decimal_macros::dec;
+
+    fn intent(symbol: &str, px: Decimal, sz: Decimal) -> OrderIntent {
+        OrderIntent {
+            cloid: Cloid::new(),
+            symbol: Symbol::new(symbol),
+            side: Side::Long,
+            px,
+            sz,
+            tif: Tif::Gtc,
+            reduce_only: false,
+        }
+    }
+
+    #[test]
+    fn disabled_passes_request() {
+        let g = SafetyGate::disabled();
+        g.check_request(&Symbol::new("XYZ"), dec!(100), Some(dec!(99999)))
+            .expect("disabled gate should never reject");
+    }
+
+    #[test]
+    fn disabled_passes_intent() {
+        let g = SafetyGate::disabled();
+        g.check_intent(&intent("XYZ", dec!(99999), dec!(1)))
+            .expect("disabled gate should never reject");
+    }
+
+    #[test]
+    fn allow_list_rejects_non_member() {
+        let g = SafetyGate::from_args("ETH,BTC", None, false).unwrap();
+        let err = g
+            .check_request(&Symbol::new("XRP"), dec!(1), Some(dec!(1)))
+            .expect_err("XRP must be rejected");
+        assert!(matches!(err, SafetyViolation::SymbolNotAllowed { .. }));
+    }
+
+    #[test]
+    fn allow_list_accepts_member() {
+        let g = SafetyGate::from_args("ETH,BTC", None, false).unwrap();
+        g.check_request(&Symbol::new("ETH"), dec!(0.001), Some(dec!(2400)))
+            .expect("ETH must pass");
+    }
+
+    #[test]
+    fn notional_cap_rejects_over() {
+        let g = SafetyGate::from_args("ETH", Some(10), false).unwrap();
+        // 0.005 * 2400 = 12 → over cap of 10
+        let err = g
+            .check_request(&Symbol::new("ETH"), dec!(0.005), Some(dec!(2400)))
+            .expect_err("notional 12 > 10 must be rejected");
+        match err {
+            SafetyViolation::NotionalExceeded { notional, max, .. } => {
+                assert_eq!(notional, dec!(12));
+                assert_eq!(max, dec!(10));
+            }
+            other => panic!("unexpected violation: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn notional_cap_accepts_under() {
+        let g = SafetyGate::from_args("ETH", Some(10), false).unwrap();
+        // 0.004 * 2400 = 9.6 → under cap
+        g.check_request(&Symbol::new("ETH"), dec!(0.004), Some(dec!(2400)))
+            .expect("notional 9.6 <= 10 must pass");
+    }
+
+    #[test]
+    fn notional_check_skipped_without_ref_px() {
+        let g = SafetyGate::from_args("ETH", Some(10), false).unwrap();
+        // No ref_px → only allow-list check runs.
+        g.check_request(&Symbol::new("ETH"), dec!(99999), None)
+            .expect("missing ref_px must skip notional check");
+    }
+
+    #[test]
+    fn check_intent_uses_actual_px() {
+        let g = SafetyGate::from_args("ETH", Some(10), false).unwrap();
+        // px=2400 sz=0.005 = 12 → reject
+        let err = g
+            .check_intent(&intent("ETH", dec!(2400), dec!(0.005)))
+            .expect_err("notional 12 > 10 must be rejected");
+        assert!(matches!(err, SafetyViolation::NotionalExceeded { .. }));
+        // px=2400 sz=0.004 = 9.6 → ok
+        g.check_intent(&intent("ETH", dec!(2400), dec!(0.004)))
+            .expect("9.6 <= 10 must pass");
+    }
+
+    #[test]
+    fn from_args_mainnet_real_empty_fatal() {
+        let err = SafetyGate::from_args("", None, true)
+            .expect_err("empty allow-list on mainnet+real must be fatal");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("required") && msg.contains("mainnet"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
+    fn from_args_star_means_allow_all() {
+        let g = SafetyGate::from_args("*", None, true).unwrap();
+        assert!(
+            g.allow_symbols.is_none(),
+            "'*' must produce allow_symbols=None"
+        );
+        // Wildcard truly allows everything.
+        g.check_request(&Symbol::new("WHATEVER"), dec!(1), Some(dec!(1)))
+            .expect("'*' must accept any symbol");
+    }
+
+    #[test]
+    fn from_args_csv_with_whitespace() {
+        let g = SafetyGate::from_args("ETH , BTC ,LINK", None, false).unwrap();
+        let allowed = g.allow_symbols.as_ref().unwrap();
+        assert!(allowed.contains(&Symbol::new("ETH")));
+        assert!(allowed.contains(&Symbol::new("BTC")));
+        assert!(allowed.contains(&Symbol::new("LINK")));
+        assert_eq!(allowed.len(), 3);
+    }
+
+    #[test]
+    fn from_args_testnet_empty_keeps_empty_set() {
+        // Testnet+real with empty CSV: not fatal, but rejects everything.
+        let g = SafetyGate::from_args("", None, false).unwrap();
+        assert_eq!(g.allow_symbols.as_ref().unwrap().len(), 0);
+        let err = g
+            .check_request(&Symbol::new("ETH"), dec!(1), None)
+            .expect_err("empty allow-list (non-fatal mode) must still reject");
+        assert!(matches!(err, SafetyViolation::SymbolNotAllowed { .. }));
+    }
+
+    #[test]
+    fn from_args_max_notional_zero_treated_as_zero_cap() {
+        // 0 is a valid (very strict) cap, not magic.
+        let g = SafetyGate::from_args("ETH", Some(0), false).unwrap();
+        assert_eq!(g.max_notional_usd, Some(Decimal::ZERO));
+        let err = g
+            .check_intent(&intent("ETH", dec!(1), dec!(0.001)))
+            .expect_err("any notional > 0 must exceed cap of 0");
+        assert!(matches!(err, SafetyViolation::NotionalExceeded { .. }));
+    }
+}

--- a/executor/crates/executor-server/src/state.rs
+++ b/executor/crates/executor-server/src/state.rs
@@ -12,6 +12,7 @@ use executor_hl::hl_client::HlClient;
 use executor_hl::signer::Signer;
 
 use crate::registry::ExecutionRegistry;
+use crate::safety::SafetyGate;
 
 /// Server-side state. `Arc<ServerState>` is shared via `with_state`.
 pub struct ServerState {
@@ -21,6 +22,7 @@ pub struct ServerState {
     pub batch_sender: BatchSender,
     pub batch_handle: tokio::sync::Mutex<Option<BatchSenderHandle>>,
     pub registry: ExecutionRegistry,
+    pub safety: Arc<SafetyGate>,
 }
 
 impl ServerState {
@@ -30,6 +32,7 @@ impl ServerState {
         signer: Arc<dyn Signer>,
         batch_sender: BatchSender,
         batch_handle: BatchSenderHandle,
+        safety: Arc<SafetyGate>,
     ) -> Self {
         Self {
             app_state,
@@ -38,6 +41,7 @@ impl ServerState {
             batch_sender,
             batch_handle: tokio::sync::Mutex::new(Some(batch_handle)),
             registry: ExecutionRegistry::new(),
+            safety,
         }
     }
 }
@@ -47,6 +51,7 @@ impl std::fmt::Debug for ServerState {
         f.debug_struct("ServerState")
             .field("app_state", &self.app_state)
             .field("registry", &self.registry)
+            .field("safety", &self.safety)
             .finish_non_exhaustive()
     }
 }

--- a/executor/crates/executor-server/tests/integration_rest.rs
+++ b/executor/crates/executor-server/tests/integration_rest.rs
@@ -19,13 +19,17 @@ use executor_core::symbol::Symbol;
 use executor_hl::batch_sender::{spawn_batch_sender, BatchSenderConfig};
 use executor_hl::hl_client::MockHlClient;
 use executor_hl::signer::MockSigner;
-use executor_server::{build_app, ServerState};
+use executor_server::{build_app, SafetyGate, ServerState};
 
 fn lvl(px: rust_decimal::Decimal, sz: rust_decimal::Decimal) -> BookLevel {
     BookLevel { px, sz, n: 1 }
 }
 
 async fn build_state_with_seed() -> (Arc<ServerState>, Arc<MockHlClient>) {
+    build_state_with_safety(SafetyGate::disabled()).await
+}
+
+async fn build_state_with_safety(safety: SafetyGate) -> (Arc<ServerState>, Arc<MockHlClient>) {
     let app_state = Arc::new(AppState::new());
     {
         let mut b = app_state.book.write().await;
@@ -63,6 +67,7 @@ async fn build_state_with_seed() -> (Arc<ServerState>, Arc<MockHlClient>) {
         signer,
         batch_sender,
         batch_handle,
+        Arc::new(safety),
     ));
     (state, mock_hl)
 }
@@ -371,4 +376,114 @@ async fn positions_returns_seeded() {
     let body = to_bytes(resp.into_body(), 64 * 1024).await.unwrap();
     let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
     assert!(v["positions"]["BTC"].is_object());
+}
+
+// ---- PR-C2: SafetyGate Layer 1 (REST entry) ----
+
+#[tokio::test]
+async fn start_exec_symbol_not_allowed_400() {
+    // Allow-list = {BTC}; request comes in for ETH → 400.
+    let safety = SafetyGate::from_args("BTC", None, false).unwrap();
+    let (state, _) = build_state_with_safety(safety).await;
+    let app = build_app(state);
+
+    let req_body = json!({
+        "algorithm": "market",
+        "symbol": "ETH",
+        "intent": "open",
+        "target_size": "0.001",
+        "params": {}
+    });
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/exec")
+                .header("content-type", "application/json")
+                .body(Body::from(req_body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let body = to_bytes(resp.into_body(), 64 * 1024).await.unwrap();
+    let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let msg = v["message"].as_str().unwrap_or("");
+    assert!(
+        msg.contains("safety_gate") && msg.contains("symbol_not_allowed"),
+        "unexpected message: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn start_exec_notional_exceeded_400() {
+    // Allow-list = {BTC}; cap = $10. Seeded book best_bid = $49999.
+    // target_size = 0.001 → notional ≈ $50 → 400.
+    let safety = SafetyGate::from_args("BTC", Some(10), false).unwrap();
+    let (state, _) = build_state_with_safety(safety).await;
+    let app = build_app(state);
+
+    let req_body = json!({
+        "algorithm": "market",
+        "symbol": "BTC",
+        "intent": "open",
+        "target_size": "0.001",
+        "params": {}
+    });
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/exec")
+                .header("content-type", "application/json")
+                .body(Body::from(req_body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let body = to_bytes(resp.into_body(), 64 * 1024).await.unwrap();
+    let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let msg = v["message"].as_str().unwrap_or("");
+    assert!(
+        msg.contains("safety_gate") && msg.contains("notional_exceeded"),
+        "unexpected message: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn start_exec_within_caps_200() {
+    // Allow-list = {BTC}; cap = $100. Seeded book best_bid = $49999.
+    // target_size = 0.0001 → notional ≈ $5 → 200.
+    let safety = SafetyGate::from_args("BTC", Some(100), false).unwrap();
+    let (state, _) = build_state_with_safety(safety).await;
+    let app = build_app(state);
+
+    let req_body = json!({
+        "algorithm": "market",
+        "symbol": "BTC",
+        "intent": "open",
+        "target_size": "0.0001",
+        "params": {
+            "max_book_age_ms": 0,
+            "slice_timeout_ms": 50,
+            "max_attempts": 1
+        }
+    });
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/exec")
+                .header("content-type", "application/json")
+                .body(Body::from(req_body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "within-cap request should pass"
+    );
 }


### PR DESCRIPTION
## Summary

executor-server に **mainnet 投入時の誤発注を防ぐ 2 段防御 safety gate** を追加. Phase 3.5 Stage C-2.

- **Layer 1** (`routes.rs::start_exec`): symbol allow-list + 概算 notional (book.best_bid 基準) で `400 Bad Request` 即時拒否
- **Layer 2** (`BatchSender::enqueue`): algo が動的生成した `OrderIntent` を `IntentChecker` trait 経由で再検査. 違反は `HlError::ActionFormat` で algo に伝搬
- mock mode は `SafetyGate::disabled()` + `gate=None` で全通過 (CI 既存テスト無影響)
- `OrderOrCancel::Cancel` は gate を通さず素通し (`emergency_stop` の確実動作維持)

新 CLI flag (env override 対応):
- \`--mainnet-allow-symbols ETH,BTC\` (mainnet+real で **必須**, \`*\` = 明示 allow-all)
- \`--mainnet-max-notional-usd 20\` (\`Option<u64>\`, 省略 = no cap)

## Gemini deep review

\`review_log:awei5shyz83tjs2lxpu3\` (8 論点全クリア, 2 点で Claude 案を flip):
- **Q3**: warn 起動 → **fatal 起動拒否** (金融系で warn は見落とされる)
- **Q4**: \`u64=0\` sentinel → **\`Option<u64>\`** (アンチパターン)

他 6 論点 (Q1 gate 配置 / Q2 Layer 1 best_bid / Q5 testnet 適用 / Q6 cancel 素通し / Q7 immutable / Q8 error message に allow-list 露出) は Claude 推奨を Gemini が同意.

## テスト集計

- workspace 145 → **164 tests pass** (+19)
  - \`safety::tests\` 13: disabled / allow-list / notional cap / from_args 各種
  - \`batch_sender::tests\` 3: gate reject / pass / cancel skip
  - \`integration_rest\` 3: REST 入口 400 / 200 ケース
- \`cargo fmt --check\` clean
- \`cargo clippy -D warnings\` clean
- \`scripts/check_ci_local.sh\` green

## 動作確認 (offline)

- \`--mode real --base mainnet\` (空 allow-list) → \`exit 1\` + 明確なエラー
- \`--mode real --base mainnet --mainnet-allow-symbols '*'\` → \`allow_symbols=None\` で起動
- \`--mode mock\` → \`safety gate constructed allow=None max=None\` で起動 (gate disabled)

## 設計 / Plan ドキュメント

- spec: \`docs/superpowers/specs/2026-05-05-pr-c2-symbol-allowlist-size-cap-design.md\`
- plan: \`docs/superpowers/plans/2026-05-05-pr-c2-symbol-allowlist-size-cap-plan.md\`

## Test plan

- [x] \`cargo test --workspace\` (164 pass)
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` (clean)
- [x] \`cargo fmt --all -- --check\` (clean)
- [x] \`scripts/check_ci_local.sh\` (green)
- [x] mainnet+real+empty allow-list → fatal exit 1
- [x] \`--mode mock\` → gate disabled で起動
- [x] \`--mode real --base mainnet --mainnet-allow-symbols '*'\` → allow-all で起動 (PK 不在で先で停止, gate 通過は確認)
- [ ] (ユーザー実機) \`source scripts/load-env.sh && cargo run -p executor-server -- --mode real --base mainnet --mainnet-allow-symbols ETH --mainnet-max-notional-usd 20\` で 8085 listen
- [ ] (ユーザー実機 curl) \`/v1/exec\` symbol=BTC → 400, symbol=ETH 過大 → 400, symbol=ETH 通常 → 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)