### PR TITLE
feat(executor): PR-C4 — multi-symbol testnet live + Python e2e CI + operator_id (Phase 3.5 final)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
   python:
     name: python (lint + type + test)
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
 
@@ -41,10 +41,33 @@ jobs:
         run: mypy src
         continue-on-error: true  # Phase 1: warning として記録, Phase 2 で strict 必須化
 
-      - name: Pytest
+      # PR-C4 (2026-05-05): the slow-marked Python e2e tests in
+      # tests/test_executor_client_live.py spawn the Rust executor-server
+      # in mock mode. Build it (release profile) once before pytest so the
+      # `running_server` fixture finds the binary.
+      - name: Install Rust toolchain (for e2e binary)
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo (e2e build)
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            executor/target
+          key: ${{ runner.os }}-cargo-e2e-${{ hashFiles('executor/Cargo.lock', 'executor/**/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-e2e-
+            ${{ runner.os }}-cargo-
+
+      - name: Build executor-server (release) for e2e
+        working-directory: executor
+        run: cargo build --release -p executor-server
+
+      - name: Pytest (incl. mock e2e via executor-server)
         env:
           PYTHONDONTWRITEBYTECODE: "1"
-        run: pytest -q -m "not live and not slow" --cov=src --cov-report=term-missing
+        run: pytest -q -m "not live" --cov=src --cov-report=term-missing
 
   rust:
     name: rust (fmt + clippy + test)

--- a/docs/HANDOFF-2026-05-05.md
+++ b/docs/HANDOFF-2026-05-05.md
@@ -472,6 +472,95 @@ cargo run -p executor-server -- ... --baseline-guard false
 - e2e: ユーザー server 起動 → Python connector (`src/executor/client.py`) から HTTP request → 1 ETH ALO place → 即時 cancel
 - これで Phase 3.5 完成
 
+---
+
+## 12. PR-C4 完了 + Phase 3.5 完成宣言 (2026-05-05)
+
+### 完了 PR
+- PR #76 想定: `feat(executor): PR-C4 — multi-symbol testnet live + Python e2e CI + operator_id`
+- branch: `feat/pr-c4-multi-symbol-and-e2e`
+- spec: `docs/superpowers/specs/2026-05-05-pr-c4-multi-symbol-live-and-e2e-design.md`
+- plan: `docs/superpowers/plans/2026-05-05-pr-c4-multi-symbol-live-and-e2e-plan.md`
+
+### Gemini deep review (review_log)
+6 論点中 1 で flip (Q3+Q8): Claude は CI 除外を推奨したが Gemini は **mock e2e を CI に組み込み +
+session-scoped cargo build cache** を強推奨. これを採用.
+
+### 主な変更点
+1. **Python connector `operator_id`** (`src/executor/client.py`): 全 POST に `X-Operator-ID` header. GET は無タグ
+2. **Server audit log**: `start_exec` / `cancel_exec` に `HeaderMap` extractor + `tracing::info!(operator,...)`
+3. **e2e 8 件を CI に組み込み**: `tests/test_executor_client_live.py` から `@pytest.mark.live` 削除. `slow` のみ.
+   `running_server` fixture を function scope に変更 (PR-C3 emergency_stop の state mutation 対策)
+4. **CI workflow**: python job に Rust toolchain + cargo cache + `cargo build --release -p executor-server` 追加.
+   pytest filter を `-m "not live"` に変更 (`slow` は通す)
+5. **testnet multi-symbol live test placeholder**: `executor-hl/tests/live_emergency_stop_multi_testnet.rs`.
+   ETH + BTC を ALO post-only で同時 place → `cancel_orders(&[c1,c2])` 単一バッチで両 cancel 検証.
+   Claude session では実行不可 (`#[cfg(feature = "live")]` + `HL_TESTNET_AGENT_PK`)
+6. **`scripts/load-env-testnet.sh`**: testnet PK loader template. mainnet 鍵と完全分離 (pass-store separate entry)
+
+### テスト集計 (PR-C4 後)
+| 区分 | 件数 |
+|---|---|
+| Rust workspace | **173 tests pass** (PR-C3 から変化なし) |
+| Python `pytest -m "not live"` | **既存 mock + e2e 8 件含む全 pass** |
+| 内訳 (新規 Python) | mock test_executor_client +3 (operator_id), e2e +3 (PR-C3 idempotency / 503 / operator_id) |
+
+`cargo fmt --check` / `cargo clippy -D warnings` / `scripts/check_ci_local.sh` 全クリーン.
+
+### 重要設計ファイル (PR-C4)
+| 機能 | パス |
+|---|---|
+| Python connector operator_id | `src/executor/client.py::ExecutorClient.__init__` |
+| Server audit log | `executor-server/src/routes.rs::start_exec`/`cancel_exec` の `tracing::info!(operator,...)` |
+| e2e CI 組み込み | `tests/test_executor_client_live.py` (live marker 削除) |
+| testnet live placeholder | `executor/crates/executor-hl/tests/live_emergency_stop_multi_testnet.rs` |
+| testnet PK loader | `scripts/load-env-testnet.sh` |
+| CI workflow | `.github/workflows/ci.yml` (Rust toolchain + binary build 追加) |
+
+### Phase 3.5 完成宣言
+
+PR-A 〜 PR-C4 まで完了. **executor-server は production 投入可能状態** に到達:
+
+| Stage | 内容 |
+|---|---|
+| ✅ PR-A | mainnet read-only parser (clearinghouseState / openOrders / l2Book / meta / userRole) |
+| ✅ PR-B1 | EIP-712 Eip712AgentSigner (HL python-sdk と byte-identical 10/10) |
+| ✅ PR-B2a | RealHlClient::place_orders/cancel_orders + mockito 9 tests |
+| ✅ PR-B2b | mainnet 1-round-trip 実機実証 (`place oid=411376566471 → cancel ok`) |
+| ✅ PR-C1 | MetaCache + executor-server `--mode real --base mainnet` 切替 |
+| ✅ PR-C2 | symbol allowlist + size cap (2 段防御 mainnet safety gate) |
+| ✅ PR-C3 | baseline-diff guard + idempotent emergency_stop + 503 after stop |
+| ✅ PR-C4 | testnet multi-cancel placeholder + Python e2e CI + operator_id audit |
+
+mainnet 投入手順:
+```bash
+source scripts/load-env.sh
+cd executor
+cargo run -p executor-server -- --mode real --base mainnet \
+  --mainnet-allow-symbols ETH \
+  --mainnet-max-notional-usd 20 \
+  --master-address 0xfe3e32cd4443e395ec0400bf828a34309e517d2d
+# → safety gate constructed allow_symbols=Some({Symbol("ETH")}) max_notional_usd=Some(20)
+#    BaselineGuard captured baseline_size=N
+#    executor-server listening bind=0.0.0.0:8085
+```
+
+Python から:
+```python
+async with ExecutorClient("http://127.0.0.1:8085", operator_id="alice@desk") as cli:
+    h = await cli.health()
+    resp = await cli.start("market", "ETH", "open", "0.005")  # ~$12 notional
+    # 数秒後 cancel_exec or status poll
+```
+
+### Phase 4 (次フェーズ) 想定 PR
+- PR-D1: WS subscriber 本実装 (tokio-tungstenite で実 WS 接続 + 自動再接続 + 5min reconcile)
+- PR-D2: 片肺リスク (multi-order partial failure) の検知 + 自動 recovery
+- PR-D3: by_oid cancel 経路 (cancelByCloid 以外の HL action サポート)
+- PR-D4: signal handler + graceful shutdown (SIGTERM で BaselineGuard 含む全 task を綺麗に終了)
+- PR-D5: HIP-3 multi-dex MetaCache::build (xyz / flx / vntl 等 8 dex)
+
 完.
+
 
 

--- a/docs/superpowers/plans/2026-05-05-pr-c4-multi-symbol-live-and-e2e-plan.md
+++ b/docs/superpowers/plans/2026-05-05-pr-c4-multi-symbol-live-and-e2e-plan.md
@@ -1,0 +1,199 @@
+# PR-C4 Implementation Plan: multi-symbol live test + Python e2e CI + operator_id
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development or superpowers:executing-plans.
+
+**Goal:** Land Phase 3.5's final piece. (1) Add `operator_id` support to the Python `ExecutorClient` so every POST audit-tags the caller. (2) Lift the existing Rust-binary-driven Python e2e tests out of the `live` marker and into CI; CI builds `executor-server --release` once and runs `pytest -m "not live"` (which now picks them up). (3) Drop a placeholder testnet multi-symbol live test under `#[cfg(feature = "live")]` for the user to drive manually.
+
+**Architecture:** Three independent pieces.
+- *Python connector*: `ExecutorClient.__init__` gains `operator_id: str | None`, `_post` injects `X-Operator-ID` when set; mock-transport tests verify both branches.
+- *Rust server audit*: `routes::start_exec` and `routes::cancel_exec` accept the `HeaderMap` extractor and emit `tracing::info!(operator, …)` so the audit chain is uniform across endpoints.
+- *Testing*: `running_server` fixture switches from `module` to `function` scope (PR-C3 emergency_stop mutates global state), `@pytest.mark.live` is dropped from existing tests, three new e2e tests cover idempotency + 503 + operator_id round-trip. `scripts/check_ci_local.sh` and the GitHub Actions workflow get a `cargo build --release -p executor-server` step before pytest.
+
+**Tech Stack:** Python 3.12 + httpx + pytest + pytest-asyncio (existing). Rust 2021 (existing). No new deps.
+
+---
+
+## File Structure
+
+| Path | Action | Notes |
+|---|---|---|
+| `src/executor/client.py` | Modify | Add `operator_id` parameter; `_post` injects `X-Operator-ID` header. ~20 LOC delta. |
+| `tests/test_executor_client.py` | Modify | 2 new mock-transport tests for operator_id. |
+| `executor/crates/executor-server/src/routes.rs` | Modify | `start_exec` and `cancel_exec` accept `HeaderMap` and log `operator`. |
+| `tests/test_executor_client_live.py` | Modify | Drop `@pytest.mark.live` from existing tests. Switch fixture to function scope. Add 3 e2e tests. |
+| `scripts/check_ci_local.sh` | Modify | Add `cargo build --release -p executor-server` step. Update pytest filter to `-m "not live"`. |
+| `.github/workflows/*.yml` | Modify (if present) | Same updates: build + drop `slow` from filter. |
+| `executor/crates/executor-hl/tests/live_emergency_stop_multi_testnet.rs` | Create | Placeholder live test for testnet multi-symbol cancel; gated by `#[cfg(feature = "live")]`. ~150 LOC. |
+| `scripts/load-env-testnet.sh` | Create | Template for users to source testnet PK from `~/.password-store/diff-old-new/hl-testnet/agent-pk`. |
+| `docs/HANDOFF-2026-05-05.md` | Modify | Append §12 PR-C4 完了 + Phase 3.5 完成宣言. |
+
+---
+
+## Step 1: Python connector `operator_id`
+
+- [ ] Edit `src/executor/client.py::ExecutorClient`:
+  - Add parameter: `def __init__(self, base_url, operator_id=None, timeout=10.0)`.
+  - Store `self._operator_id = operator_id`.
+  - Update `_post(self, path, payload)` to merge `{"X-Operator-ID": self._operator_id}` into headers when set.
+  - Don't touch `_get` (audit POSTs only).
+- [ ] Run: `python -m pytest tests/test_executor_client.py -q`.
+
+## Step 2: Mock-transport tests for operator_id
+
+- [ ] In `tests/test_executor_client.py`, add 2 tests:
+  ```python
+  @pytest.mark.asyncio
+  async def test_post_includes_operator_id_when_set(monkeypatch):
+      seen_headers: dict = {}
+      def handler(req):
+          seen_headers.update(dict(req.headers))
+          return httpx.Response(200, json={"aborted_executions": 0, "cancelled_orders": 0})
+      cli = _patched_client(monkeypatch, handler)
+      cli._operator_id = "alice@desk"  # or pass via __init__ if patched_client accepts
+      async with cli:
+          await cli.emergency_stop()
+      assert seen_headers.get("x-operator-id") == "alice@desk"
+
+  @pytest.mark.asyncio
+  async def test_post_omits_operator_id_when_none(monkeypatch):
+      ...  # symmetric: assert "x-operator-id" not in seen_headers
+  ```
+  - Adjust `_patched_client` helper to accept `operator_id` kwarg if needed.
+
+## Step 3: Server-side audit log
+
+- [ ] In `executor/crates/executor-server/src/routes.rs::start_exec`:
+  - Change signature to accept `headers: axum::http::HeaderMap`.
+  - Read `operator` (default `"unknown"`) and emit `tracing::info!(operator, algorithm = %req.algorithm, symbol = %req.symbol, "start_exec")` after the safety-gate check.
+- [ ] Same change in `cancel_exec` (no operator yet, add it).
+- [ ] Run: `cd executor && cargo build -p executor-server`.
+
+## Step 4: Update existing Python e2e tests
+
+- [ ] In `tests/test_executor_client_live.py`:
+  - Remove `@pytest.mark.live` from every existing `test_e2e_*` function. Keep `@pytest.mark.slow`.
+  - Change `running_server` fixture to `scope="function"` (PR-C3 emergency_stop mutates `shutdown_initiated`).
+  - Update the docstring to reflect the new CI inclusion.
+
+## Step 5: New Python e2e tests for PR-C3 features
+
+- [ ] In `tests/test_executor_client_live.py`, add:
+  ```python
+  @pytest.mark.slow
+  @pytest.mark.asyncio
+  async def test_e2e_emergency_stop_with_operator_id(running_server: str) -> None:
+      async with ExecutorClient(running_server, operator_id="alice@desk") as cli:
+          body = await cli.emergency_stop()
+      assert body["aborted_executions"] == 0
+
+  @pytest.mark.slow
+  @pytest.mark.asyncio
+  async def test_e2e_idempotent_emergency_stop(running_server: str) -> None:
+      async with ExecutorClient(running_server) as cli:
+          first = await cli.emergency_stop()
+          second = await cli.emergency_stop()
+      assert second["aborted_executions"] == 0
+      assert second["cancelled_orders"] == 0
+
+  @pytest.mark.slow
+  @pytest.mark.asyncio
+  async def test_e2e_503_after_emergency_stop(running_server: str) -> None:
+      async with ExecutorClient(running_server) as cli:
+          await cli.emergency_stop()
+          with pytest.raises(Exception, match="HTTP 503"):
+              await cli.start(
+                  algorithm="market", symbol="BTC", intent="open", target_size="0.001",
+              )
+  ```
+
+## Step 6: CI script update
+
+- [ ] Edit `scripts/check_ci_local.sh`:
+  - Before `[python 4/4] Pytest`, add a `[rust 0/3] cargo build --release -p executor-server` step.
+  - Change pytest filter from `-m "not live and not slow"` to `-m "not live"`.
+- [ ] Inspect `.github/workflows/*.yml` (if present) and apply the same change.
+
+## Step 7: Workspace + Python checks
+
+- [ ] `cd executor && cargo fmt --all && cargo build --workspace && cargo test --workspace`.
+- [ ] `cd .. && .venv/bin/pytest -m "not live"` — expect new e2e tests to pass.
+- [ ] `bash scripts/check_ci_local.sh` — green.
+
+## Step 8: testnet live test placeholder
+
+- [ ] Create `executor/crates/executor-hl/tests/live_emergency_stop_multi_testnet.rs`:
+  ```rust
+  #![cfg(feature = "live")]
+  // ENV:
+  //   HL_TESTNET_AGENT_PK — testnet 1-shot agent wallet PK (from pass-store)
+  //   HL_TESTNET_MASTER   — testnet master EOA (public address)
+  //
+  // Run:
+  //   source scripts/load-env-testnet.sh
+  //   cd executor
+  //   cargo test -p executor-hl --features live live_testnet_multi_cancel \
+  //     -- --nocapture --test-threads=1
+  //
+  // 2 件並行 place (ETH + BTC, ALO post-only, $11 notional each) →
+  // cancel_orders(&[c1, c2]) で両方 cancelled. existing positions unchanged.
+  ```
+  - 同じパターンを `live_mainnet_place_cancel.rs` から流用. mainnet → testnet config に切替.
+  - 2 symbol 同時 place → cancel_orders(&[c1, c2]) → 両方 cancelled assert.
+  - `MetaCache::build` で testnet meta 取得.
+  - Optional: 起動前 baseline snapshot 取得, 終了時 unchanged 検証.
+
+## Step 9: load-env-testnet.sh template
+
+- [ ] Create `scripts/load-env-testnet.sh`:
+  ```bash
+  #!/usr/bin/env bash
+  # Source-only. Loads testnet PK + master into the calling shell.
+  # Mirrors load-env.sh but reads from a separate pass-store entry so
+  # mainnet and testnet keys never share a process.
+  set -e
+  if ! [[ "$_" =~ "load-env-testnet.sh" || -n "${BASH_SOURCE[0]}" ]]; then
+      echo "must be sourced, not executed"
+      exit 1
+  fi
+  export HL_TESTNET_AGENT_PK="$(pass show diff-old-new/hl-testnet/agent-pk 2>/dev/null || true)"
+  if [[ -z "$HL_TESTNET_AGENT_PK" ]]; then
+      echo "WARN: no testnet agent-pk in pass-store. Set with: pass insert diff-old-new/hl-testnet/agent-pk"
+  fi
+  # Public addresses are not secret; load from .env.testnet if available.
+  if [[ -f .env.testnet ]]; then
+      set -a
+      source .env.testnet
+      set +a
+  fi
+  ```
+  - Note: `.env.testnet` itself is git-ignored (HL_TESTNET_MASTER + agent-related metadata).
+  - Document pass-store key path in `CLAUDE.md` (project) — reuse the existing PK-protection rules.
+
+## Step 10: HANDOFF doc + Phase 3.5 完成宣言
+
+- [ ] Append `## 12. PR-C4 完了 + Phase 3.5 完成宣言` to `docs/HANDOFF-2026-05-05.md` listing all PRs from PR-A through PR-C4 and stating the system is production-ready (mainnet small-size tested, mock e2e covered in CI).
+
+## Step 11: Commit + push + PR
+
+- [ ] Branch: `git checkout -b feat/pr-c4-multi-symbol-and-e2e`.
+- [ ] Commits split:
+  1. `docs(spec/plan): PR-C4 multi-symbol live + Python e2e + operator_id`
+  2. `feat(client): operator_id passthrough on POST`
+  3. `feat(executor): start_exec/cancel_exec audit log`
+  4. `test(e2e): drop live marker + add PR-C3 idempotency e2e`
+  5. `chore(ci): build executor-server release before pytest`
+  6. `test(executor-hl): live_emergency_stop_multi_testnet placeholder`
+  7. `chore(env): load-env-testnet.sh template`
+  8. `docs: HANDOFF — PR-C4 完了 + Phase 3.5 完成宣言`
+- [ ] Push + `gh pr create --base develop`.
+- [ ] CI green wait + self-merge per branch strategy.
+
+---
+
+## Acceptance gates
+
+- [ ] All Rust + Python tests green.
+- [ ] CI runs the e2e tests (test names visible in CI log).
+- [ ] `start_exec` and `cancel_exec` log lines include the operator id.
+- [ ] testnet live test compiles under `--features live` (cannot run without PK).
+- [ ] HANDOFF marks Phase 3.5 complete.

--- a/docs/superpowers/specs/2026-05-05-pr-c4-multi-symbol-live-and-e2e-design.md
+++ b/docs/superpowers/specs/2026-05-05-pr-c4-multi-symbol-live-and-e2e-design.md
@@ -1,0 +1,222 @@
+# PR-C4: multi-symbol live test + Python e2e + operator_id (Phase 3.5 final) 設計
+
+**作成日**: 2026-05-05
+**ブランチ**: `feat/pr-c4-multi-symbol-and-e2e` (実装時に作成)
+**親 spec**: `docs/superpowers/specs/2026-05-05-hl-mainnet-readonly-and-minimal-order-test-design.md` Stage C
+**前提コード**: PR-C3 merged (`develop@e9e0d15`)
+**Gemini deep review**: 2026-05-05, `review_log` (5/6 同意 + Q3 で Claude を flip)
+
+## 1. 目的
+
+Phase 3.5 を完成させるため, 以下 3 件を 1 PR で:
+
+1. **multi-symbol cancel live test** (testnet + 1-shot agent wallet) — emergency_stop で multi-cancel 経路を実機検証
+2. **Python connector の `X-Operator-ID` 全 POST 対応** (HANDOFF §5.5 deferred 解消)
+3. **Python e2e test を CI に組み込む** (mock 限定. `slow` のみ marker, `live` は除外)
+
+これにより:
+- "executor-server を Python から駆動して全 round trip 通る" 証拠が CI で常時担保される
+- mainnet 投入時の audit log で誰が start_exec したか追跡可能
+- Phase 3.5 完成宣言 → Phase 4 (WS subscriber 等) へ移行
+
+## 2. 非目的
+
+- `by_oid` cancel 経路の RealHlClient 実装 (PR-D 系で別途)
+- mainnet での multi-symbol live test (testnet で十分)
+- WS 経由の即時 baseline-diff 検知 (PR-D 系)
+
+## 3. Gemini deep flip / 採用論点
+
+| Q | Claude 案 | Gemini 推奨 | 採用 |
+|---|---|---|---|
+| Q1+Q7 | testnet 新規 wallet | testnet + 1-shot key | testnet |
+| Q2 | Step A only | Step A only (責務分離) | Step A |
+| **Q3+Q8** | **CI 除外** | **CI 含める (mock 限定)** | **CI に含める** |
+| Q4 | 全 POST に operator_id | 同意 | 全 POST |
+| Q5 | by_oid 含めない | 含めない | 含めない |
+| Q6 | (a)(b)(c) で完了 | OK | (a)(b)(c) |
+
+## 4. アーキテクチャ
+
+### 4.1 Python connector の operator_id 追加
+
+```python
+class ExecutorClient:
+    def __init__(self, base_url: str, operator_id: str | None = None, timeout: float = 10.0):
+        self._base_url = base_url.rstrip("/")
+        self._operator_id = operator_id
+        self._timeout = timeout
+        self._client: httpx.AsyncClient | None = None
+
+    async def _post(self, path: str, payload: dict) -> dict:
+        headers = {}
+        if self._operator_id:
+            headers["X-Operator-ID"] = self._operator_id
+        resp = await self._http.post(f"{self._base_url}{path}", json=payload, headers=headers)
+        return self._unwrap(resp)
+```
+
+注: `_get` は header を付けない (audit は POST のみ. GET は read-only で副作用なし).
+
+### 4.2 Server 側 audit log
+
+`routes::start_exec` および `routes::cancel_exec` で `X-Operator-ID` を log 出力.
+既存 `emergency_stop` は実装済 (PR-7 から). 新規:
+
+```rust
+// routes::start_exec の先頭に追加
+let operator = headers.get("x-operator-id").and_then(|v| v.to_str().ok()).unwrap_or("unknown");
+tracing::info!(operator, algorithm = %req.algorithm, symbol = %req.symbol, "start_exec");
+```
+
+`HeaderMap` を引数で受け取る必要あり. axum extractor で簡単.
+
+### 4.3 multi-symbol live test (testnet, Step A)
+
+`executor/crates/executor-hl/tests/live_emergency_stop_multi_testnet.rs` (新規):
+
+```rust
+#![cfg(feature = "live")]
+
+const ENV_TESTNET_AGENT_PK: &str = "HL_TESTNET_AGENT_PK";
+const ENV_TESTNET_MASTER: &str = "HL_TESTNET_MASTER";
+
+/// Multi-symbol cancel via cancel_orders(&[2 件]). testnet only — fails fast
+/// if HL_TESTNET_AGENT_PK is unset.
+#[tokio::test]
+async fn live_testnet_multi_cancel_two_symbols() {
+    // 1. testnet client + signer (HL_TESTNET_AGENT_PK 必須)
+    // 2. ETH + BTC 2 件をそれぞれ別 cloid で place (ALO post-only, $11 notional each)
+    // 3. cancel_orders(&[c1, c2]) → 両方 cancelled で返ること
+    // 4. existing positions が変化しないこと
+}
+```
+
+CI の `--features live` は **付けない**. Claude session でも実行されない. ユーザー実行用 placeholder.
+
+### 4.4 Python e2e test を CI に組み込む
+
+既存 `tests/test_executor_client_live.py` から `@pytest.mark.live` を外す. `@pytest.mark.slow` のみ残す.
+CI marker filter を `-m "not live"` に変更 (`slow` は通す).
+
+ただし binary が前提なので, CI workflow に **`cargo build --release -p executor-server` を pytest 前に実行**.
+
+CI 時間試算:
+- `cargo build --release -p executor-server`: ~30s (cold) / ~5s (cached)
+- `pytest -m "not live"`: 既存 +5s 程度
+- 全体 +30s 程度. CI 時間 < 3 分は維持.
+
+ローカル `scripts/check_ci_local.sh` も同期: `pytest -m "not live"` に変更 + 事前に `cargo build --release -p executor-server`.
+
+### 4.5 既存 test_executor_client_live.py の改修
+
+```diff
+- @pytest.mark.live
+  @pytest.mark.slow
+  @pytest.mark.asyncio
+  async def test_e2e_health_and_algorithms(running_server: str) -> None:
+```
+
+新規テスト:
+```python
+@pytest.mark.slow
+@pytest.mark.asyncio
+async def test_e2e_emergency_stop_with_operator_id(running_server: str) -> None:
+    async with ExecutorClient(running_server, operator_id="alice@desk") as cli:
+        body = await cli.emergency_stop()
+    assert body["aborted_executions"] == 0
+
+@pytest.mark.slow
+@pytest.mark.asyncio
+async def test_e2e_idempotent_emergency_stop(running_server: str) -> None:
+    """PR-C3 idempotency check via Python connector."""
+    async with ExecutorClient(running_server) as cli:
+        a = await cli.emergency_stop()
+        b = await cli.emergency_stop()
+    assert b["aborted_executions"] == 0
+    assert b["cancelled_orders"] == 0
+
+@pytest.mark.slow
+@pytest.mark.asyncio
+async def test_e2e_503_after_emergency_stop(running_server: str) -> None:
+    """PR-C3 503 check via Python connector."""
+    async with ExecutorClient(running_server) as cli:
+        await cli.emergency_stop()
+        with pytest.raises(Exception, match="HTTP 503"):
+            await cli.start(algorithm="market", symbol="BTC", intent="open", target_size="0.01")
+```
+
+注: `running_server` fixture は scope="module" だが PR-C3 emergency_stop は state を mutate するので, テスト間で副作用が出る. **fixture を function scope に変更** が必要 — もしくは新規 fixture `fresh_server` (per-test).
+
+## 5. テスト計画
+
+### 5.1 既存 unit tests (executor-server, hl-client)
+影響なし. operator_id は header だけなので server 側で受け取り log するだけ.
+
+### 5.2 新規 Python tests (CI 含む)
+- `test_executor_client.py::test_post_includes_operator_id_when_set` (mock transport)
+- `test_executor_client.py::test_post_omits_operator_id_when_none` (mock transport)
+- `test_executor_client_live.py::test_e2e_emergency_stop_with_operator_id` (live binary)
+- `test_executor_client_live.py::test_e2e_idempotent_emergency_stop` (live binary)
+- `test_executor_client_live.py::test_e2e_503_after_emergency_stop` (live binary)
+
+### 5.3 新規 Rust live test (CI 除外)
+- `live_emergency_stop_multi_testnet.rs::live_testnet_multi_cancel_two_symbols`
+- `#[cfg(feature = "live")]` で CI から除外
+- ユーザー実行: `source scripts/load-env-testnet.sh && cargo test --features live live_testnet_multi_cancel`
+
+注: testnet 用 `load-env-testnet.sh` は新規. `HL_TESTNET_AGENT_PK` を pass-store から export する想定.
+鍵管理は `~/.password-store/diff-old-new/hl-testnet/agent-pk.gpg` で別保管 (mainnet 鍵と分離).
+
+ユーザーが手元で testnet wallet を発行 → pass-store に保存 → `load-env-testnet.sh` を起動の流れは別 README で.
+PR-C4 では `load-env-testnet.sh` の **template** だけ提供 (PK 値は user が埋める).
+
+## 6. 実装順序
+
+1. `src/executor/client.py::ExecutorClient` に `operator_id` 追加 (init + `_post`)
+2. `tests/test_executor_client.py` で operator_id mock test 2 件
+3. `routes.rs::start_exec` で `X-Operator-ID` log 出力 (HeaderMap extractor)
+4. `tests/test_executor_client_live.py` で `@pytest.mark.live` 外す + 新 3 テスト
+5. running_server fixture を function scope に変更 (state mutation 対策)
+6. CI workflow / `scripts/check_ci_local.sh` で `pytest -m "not live"` + `cargo build --release` 事前
+7. `executor-hl/tests/live_emergency_stop_multi_testnet.rs` 新規 (`#[cfg(feature = "live")]`)
+8. `scripts/load-env-testnet.sh` template 新規
+9. `docs/HANDOFF-2026-05-05.md` で Phase 3.5 完成宣言
+10. fmt / clippy / test / CI script
+11. commit / push / PR (--base develop)
+
+## 7. リスクとフォールバック
+
+| リスク | 影響 | 対策 |
+|---|---|---|
+| running_server fixture の module scope で state shared | テスト間で fall-through | function scope に変更 |
+| CI で binary build が遅い | CI 時間 +30s | `cargo build --release` cache (Github Actions) で吸収 |
+| Python e2e の port competition | flaky | `_free_port()` を使う (既存) |
+| testnet wallet が別人の鍵漏洩 | testnet で実損失なし | 1-shot key + pass-store 管理. PR-C4 では template のみ提供 |
+| HL min notional $10 in testnet | 不明 (testnet は仕様変動) | live test 内で MIN_NOTIONAL_USD assertion で fail-fast |
+
+## 8. 受入条件
+
+- [ ] `cargo build --workspace` clean
+- [ ] `cargo test --workspace` 全 pass (173 + ~? 件 = 同程度)
+- [ ] Python `pytest -m "not live"` で e2e tests も実行され全 pass
+- [ ] `scripts/check_ci_local.sh` green (新ロジックで)
+- [ ] `cargo fmt --check` / `cargo clippy -D warnings` clean
+- [ ] CI green (mock e2e 込み)
+- [ ] Phase 3.5 完成宣言が HANDOFF doc に書かれる
+
+## 9. Phase 3.5 完成判定
+
+PR-C4 merge をもって Phase 3.5 完成. 以下が全て揃った状態:
+
+- ✅ HL mainnet read-only parser (PR-A)
+- ✅ EIP-712 signer (PR-B1, byte-identical 10/10)
+- ✅ RealHlClient::place_orders/cancel_orders + mainnet 1-round-trip (PR-B2a/b)
+- ✅ MetaCache + executor-server real mode 切替 (PR-C1)
+- ✅ symbol allowlist + size cap 2 段防御 (PR-C2)
+- ✅ baseline-diff guard + idempotent emergency_stop (PR-C3)
+- ✅ multi-symbol cancel live test placeholder + Python e2e CI 組み込み + operator_id (PR-C4)
+
+未完: WS subscriber 本実装 (Phase 4 PR-D 系), 片肺リスク (PR-D), by_oid cancel (PR-D)
+
+PR-C4 後の executor-server は **production 投入可能状態**.

--- a/executor/crates/executor-hl/tests/live_emergency_stop_multi_testnet.rs
+++ b/executor/crates/executor-hl/tests/live_emergency_stop_multi_testnet.rs
@@ -1,0 +1,201 @@
+//! PR-C4 placeholder: testnet multi-symbol cancel live test.
+//!
+//! Two HL testnet ALO post-only orders (ETH + BTC, ~$11 notional each) are
+//! placed back-to-back; a single `cancel_orders(&[c1, c2])` then cancels both.
+//! Existing positions and open orders on the master EOA must remain unchanged.
+//!
+//! Required env (testnet — separate from mainnet PK):
+//!   HL_TESTNET_AGENT_PK — testnet agent wallet 64-hex private key
+//!   HL_TESTNET_MASTER   — testnet master EOA (public hex address)
+//!
+//! Run only by the user from a shell where `source scripts/load-env-testnet.sh`
+//! has been executed:
+//!
+//!     source scripts/load-env-testnet.sh
+//!     cd executor
+//!     cargo test -p executor-hl --features live \
+//!       live_testnet_multi_cancel_two_symbols \
+//!       -- --nocapture --test-threads=1
+//!
+//! Do NOT enable `--features live` in CI. The Claude PreToolUse hook
+//! blocks `source scripts/load-env-testnet.sh`, so this test cannot fire
+//! from the Claude session — only the user's interactive shell.
+
+#![cfg(feature = "live")]
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use executor_core::cloid::Cloid;
+use executor_core::intent::{CancelIntent, OrderIntent};
+use executor_core::symbol::Symbol;
+use executor_core::types::{Address, Side, Tif};
+use executor_hl::hl_client::{HlClient, HlConfig, RealHlClient};
+use executor_hl::signer::Eip712AgentSigner;
+use rust_decimal::Decimal;
+use rust_decimal_macros::dec;
+use secrecy::SecretString;
+use std::sync::Arc;
+use std::time::Duration;
+
+const TARGET_NOTIONAL_USD: Decimal = dec!(11);
+const MAX_NOTIONAL_USD: Decimal = dec!(50);
+const MIN_NOTIONAL_USD: Decimal = dec!(10);
+const TICKS_BELOW_BID: usize = 100;
+const POST_PLACE_WAIT_MS: u64 = 200;
+
+fn master_address() -> Address {
+    let s = std::env::var("HL_TESTNET_MASTER")
+        .expect("HL_TESTNET_MASTER env required (testnet master EOA hex address)");
+    Address::new(s)
+}
+
+fn agent_pk_secret() -> SecretString {
+    let s = std::env::var("HL_TESTNET_AGENT_PK")
+        .expect("HL_TESTNET_AGENT_PK env required (run `source scripts/load-env-testnet.sh`)");
+    SecretString::new(s.into())
+}
+
+async fn make_client() -> RealHlClient {
+    let signer = Arc::new(
+        Eip712AgentSigner::from_secret(agent_pk_secret(), false /* is_mainnet */)
+            .expect("Eip712AgentSigner::from_secret failed; HL_TESTNET_AGENT_PK malformed?"),
+    );
+    let bootstrap = RealHlClient::bootstrap(HlConfig::testnet(), signer);
+    let meta = std::sync::Arc::new(
+        executor_hl::meta::MetaCache::build(&bootstrap, &[None])
+            .await
+            .expect("MetaCache::build failed at PR-C4 testnet live test setup"),
+    );
+    bootstrap.with_meta(meta)
+}
+
+/// Compute a tick-grid-aligned safe-distance order price + a notional-targeted
+/// size. Mirrors the pattern from `live_mainnet_place_cancel.rs` so prices
+/// stay HL-valid by construction.
+async fn build_place_intent(client: &RealHlClient, symbol: &Symbol, cloid: Cloid) -> OrderIntent {
+    let book = client
+        .fetch_book_snapshot(symbol)
+        .await
+        .unwrap_or_else(|e| panic!("fetch {symbol} book failed: {e}"));
+    let best_bid = book
+        .best_bid()
+        .unwrap_or_else(|| panic!("{symbol} best_bid missing"));
+    assert!(book.bids.len() >= 2, "{symbol}: need 2 bid levels");
+    let tick = book.bids[0].px - book.bids[1].px;
+    let order_px = best_bid - tick * Decimal::from(TICKS_BELOW_BID);
+    let raw_sz = TARGET_NOTIONAL_USD / order_px;
+    let order_sz = raw_sz.round_dp_with_strategy(4, rust_decimal::RoundingStrategy::ToZero);
+    let notional = order_px * order_sz;
+    assert!(
+        notional >= MIN_NOTIONAL_USD && notional < MAX_NOTIONAL_USD,
+        "{symbol}: notional ${} outside [{MIN_NOTIONAL_USD}, {MAX_NOTIONAL_USD})",
+        notional
+    );
+    eprintln!(
+        "{}: best_bid={} tick={} order_px={} order_sz={} notional≈${}",
+        symbol, best_bid, tick, order_px, order_sz, notional
+    );
+    OrderIntent {
+        cloid,
+        symbol: symbol.clone(),
+        side: Side::Long,
+        px: order_px,
+        sz: order_sz,
+        tif: Tif::Alo,
+        reduce_only: false,
+    }
+}
+
+#[tokio::test]
+async fn live_testnet_multi_cancel_two_symbols() {
+    let client = make_client().await;
+    let master = master_address();
+
+    // === pre-snapshot ===
+    let pre = client
+        .fetch_account_state(&master, None)
+        .await
+        .expect("fetch testnet pre");
+    eprintln!("PRE: positions={}", pre.positions.len());
+
+    // === build 2 intents (ETH + BTC) ===
+    let cloid_eth = Cloid::new();
+    let cloid_btc = Cloid::new();
+    let eth_intent = build_place_intent(&client, &Symbol::new("ETH"), cloid_eth).await;
+    let btc_intent = build_place_intent(&client, &Symbol::new("BTC"), cloid_btc).await;
+
+    // === place 2 in a single batch ===
+    let place_resp = client
+        .place_orders(&[eth_intent, btc_intent])
+        .await
+        .expect("place_orders multi network/sign error");
+    assert_eq!(place_resp.len(), 2, "expected 2 responses");
+    for (i, pr) in place_resp.iter().enumerate() {
+        eprintln!(
+            "PLACE[{}]: status={}, oid={:?}, error={:?}",
+            i, pr.status, pr.oid, pr.error
+        );
+        if pr.status == "filled" {
+            panic!(
+                "UNEXPECTED FILL on slot {} — manual recovery required (oid={:?})",
+                i, pr.oid
+            );
+        }
+        assert_eq!(
+            pr.status, "resting",
+            "slot {}: expected resting, got {} — manual cleanup may be required",
+            i, pr.status
+        );
+    }
+
+    // brief settle
+    tokio::time::sleep(Duration::from_millis(POST_PLACE_WAIT_MS)).await;
+
+    // === single batch cancel (multi-symbol) ===
+    let cancels = vec![
+        CancelIntent {
+            symbol: Symbol::new("ETH"),
+            by_cloid: Some(cloid_eth),
+            by_oid: None,
+        },
+        CancelIntent {
+            symbol: Symbol::new("BTC"),
+            by_cloid: Some(cloid_btc),
+            by_oid: None,
+        },
+    ];
+    let cancel_resp = client
+        .cancel_orders(&cancels)
+        .await
+        .expect("cancel_orders multi network/sign error");
+    assert_eq!(cancel_resp.len(), 2);
+    for (i, cr) in cancel_resp.iter().enumerate() {
+        eprintln!("CANCEL[{}]: status={}, error={:?}", i, cr.status, cr.error);
+        assert_eq!(
+            cr.status, "cancelled",
+            "slot {}: expected cancelled, got {}",
+            i, cr.status
+        );
+    }
+
+    // === post-snapshot — existing positions unchanged ===
+    let post = client
+        .fetch_account_state(&master, None)
+        .await
+        .expect("fetch testnet post");
+    eprintln!("POST: positions={}", post.positions.len());
+    for (sym, pre_pos) in &pre.positions {
+        let post_pos = post
+            .positions
+            .get(sym)
+            .unwrap_or_else(|| panic!("symbol {sym} disappeared on testnet"));
+        assert_eq!(
+            pre_pos.size, post_pos.size,
+            "{sym} szi changed during multi-symbol cancel test!"
+        );
+    }
+
+    eprintln!(
+        "✓ testnet multi-symbol cancel success: ETH cloid={} + BTC cloid={} both cancelled",
+        cloid_eth, cloid_btc
+    );
+}

--- a/executor/crates/executor-server/src/routes.rs
+++ b/executor/crates/executor-server/src/routes.rs
@@ -93,6 +93,7 @@ pub struct StartExecResponse {
 
 pub async fn start_exec(
     State(s): State<Arc<ServerState>>,
+    headers: axum::http::HeaderMap,
     Json(req): Json<StartExecRequest>,
 ) -> Result<Json<StartExecResponse>, ServerError> {
     // PR-C3: refuse new work after an emergency_stop has been initiated.
@@ -105,6 +106,19 @@ pub async fn start_exec(
     }
 
     validate_algorithm_name(&req.algorithm)?;
+
+    // PR-C4: audit chain — every operator-driven POST gets logged with the
+    // operator id. The client must opt in via `ExecutorClient(operator_id=...)`.
+    let operator = headers
+        .get("x-operator-id")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("unknown");
+    tracing::info!(
+        operator,
+        algorithm = %req.algorithm,
+        symbol = %req.symbol,
+        "start_exec",
+    );
 
     // PR-C2 Layer 1 (REST entry): symbol allow-list + rough notional cap using
     // book.best_bid as the reference price. Strict per-order check happens at
@@ -228,6 +242,7 @@ pub struct CancelExecResponse {
 
 pub async fn cancel_exec(
     State(s): State<Arc<ServerState>>,
+    headers: axum::http::HeaderMap,
     Path(id): Path<String>,
 ) -> Result<Json<CancelExecResponse>, ServerError> {
     let exec_id = parse_exec_id(&id)?;
@@ -238,6 +253,11 @@ pub async fn cancel_exec(
         .ok_or_else(|| ServerError::NotFound(id.clone()))?;
     let h = entry.read().await;
     let _ = h.abort.send(true);
+    let operator = headers
+        .get("x-operator-id")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("unknown");
+    tracing::info!(operator, exec_id = %exec_id.0, "cancel_exec");
     Ok(Json(CancelExecResponse {
         exec_id,
         abort_signaled: true,

--- a/scripts/check_ci_local.sh
+++ b/scripts/check_ci_local.sh
@@ -28,7 +28,13 @@ if [[ -d .venv ]]; then
 
     echo ""
     echo "[python 4/4] Pytest (CI と同じ marker filter)..."
-    .venv/bin/pytest -q -m "not live and not slow" --cov=src --cov-report=term-missing | tail -5
+    # PR-C4 (2026-05-05): e2e tests need executor-server release binary. Build it
+    # before pytest so the function-scoped `running_server` fixture can spawn it.
+    if [[ -d executor && -f executor/Cargo.toml ]]; then
+        echo "    -> building executor-server release for e2e tests..."
+        (cd executor && cargo build --release -p executor-server 2>&1 | tail -3)
+    fi
+    .venv/bin/pytest -q -m "not live" --cov=src --cov-report=term-missing | tail -5
 else
     echo "[python] .venv not found, skipping (run: python3.12 -m venv .venv && pip install -e '.[dev,all]')"
 fi

--- a/scripts/load-env-testnet.sh
+++ b/scripts/load-env-testnet.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# scripts/load-env-testnet.sh — testnet PK loader (PR-C4).
+#
+# Mirrors `load-env.sh` but reads from a separate pass-store entry so testnet
+# and mainnet keys never share a process. Targets HL Hyperliquid testnet.
+#
+# Usage (sourcing only):
+#   source scripts/load-env-testnet.sh
+#
+# Setup once:
+#   1. Generate a new agent wallet for testnet (1-shot key, never reused on mainnet)
+#   2. pass insert diff-old-new/hl-testnet/agent-pk
+#      → paste the 0x-prefixed 64-hex private key
+#   3. Create `.env.testnet` (git-ignored) with:
+#         HL_TESTNET_MASTER=0x...   # public master EOA address
+#         HL_TESTNET_AGENT_ADDRESS=0x...
+#
+# Output:
+#   - Exports HL_TESTNET_AGENT_PK (sourced from pass-store)
+#   - Exports HL_TESTNET_MASTER (from .env.testnet)
+#
+# Security: Claude (the assistant) must not source this script via Bash —
+# pinentry won't fire in a subprocess and the PK could leak into the transcript.
+
+set +x  # ensure xtrace stays off so PK never appears in shell logs
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    echo "ERROR: must be sourced, not executed: source scripts/load-env-testnet.sh" >&2
+    exit 1
+fi
+
+env_file=".env.testnet"
+
+if [[ ! -f "${env_file}" ]]; then
+    echo "ERROR: ${env_file} not found in $(pwd)" >&2
+    echo "  Create it (git-ignored) with at least:" >&2
+    echo "    HL_TESTNET_MASTER=0x..." >&2
+    return 1
+fi
+
+# Non-secret metadata export
+set -a
+# shellcheck disable=SC1090
+source "${env_file}"
+set +a
+
+if ! command -v pass >/dev/null 2>&1; then
+    echo "ERROR: 'pass' not installed. Run: sudo apt install pass" >&2
+    return 1
+fi
+
+if ! pass ls diff-old-new/hl-testnet/agent-pk >/dev/null 2>&1; then
+    echo "ERROR: pass entry 'diff-old-new/hl-testnet/agent-pk' not found." >&2
+    echo "  Run: pass insert diff-old-new/hl-testnet/agent-pk" >&2
+    return 1
+fi
+
+_pk=$(pass show diff-old-new/hl-testnet/agent-pk 2>&1)
+_rc=$?
+if [[ ${_rc} -ne 0 ]] || [[ -z "${_pk}" ]]; then
+    echo "ERROR: pass show failed (rc=${_rc})." >&2
+    echo "  - interactive shell から実行していますか?" >&2
+    echo "  - gpg-agent / pinentry は動いていますか?" >&2
+    unset _pk
+    return 1
+fi
+
+if [[ ! "${_pk}" =~ ^0x[0-9a-fA-F]{64}$ ]]; then
+    echo "ERROR: PK format unexpected (length=$(echo -n "${_pk}" | wc -c))" >&2
+    unset _pk
+    return 1
+fi
+
+export HL_TESTNET_AGENT_PK="${_pk}"
+unset _pk
+
+echo "OK: env=${env_file} loaded; HL_TESTNET_AGENT_PK exported (length=${#HL_TESTNET_AGENT_PK})"
+echo "    HL_TESTNET_MASTER=${HL_TESTNET_MASTER:-<unset>}"
+echo "    HL_TESTNET_AGENT_ADDRESS=${HL_TESTNET_AGENT_ADDRESS:-<unset>}"

--- a/src/executor/client.py
+++ b/src/executor/client.py
@@ -77,8 +77,14 @@ class ExecutorClient:
             ...
     """
 
-    def __init__(self, base_url: str, timeout: float = 10.0):
+    def __init__(
+        self,
+        base_url: str,
+        operator_id: str | None = None,
+        timeout: float = 10.0,
+    ):
         self._base_url = base_url.rstrip("/")
+        self._operator_id = operator_id
         self._timeout = timeout
         self._client: httpx.AsyncClient | None = None
 
@@ -179,7 +185,16 @@ class ExecutorClient:
         return self._unwrap(resp)
 
     async def _post(self, path: str, payload: dict[str, Any]) -> dict[str, Any]:
-        resp = await self._http.post(f"{self._base_url}{path}", json=payload)
+        # PR-C4: every POST audit-tags the caller via X-Operator-ID.
+        # GETs are read-only and intentionally untagged.
+        headers: dict[str, str] = {}
+        if self._operator_id:
+            headers["X-Operator-ID"] = self._operator_id
+        resp = await self._http.post(
+            f"{self._base_url}{path}",
+            json=payload,
+            headers=headers or None,
+        )
         return self._unwrap(resp)
 
     @staticmethod

--- a/tests/test_executor_client.py
+++ b/tests/test_executor_client.py
@@ -25,7 +25,11 @@ def _make_mock_transport(handler):
     return httpx.MockTransport(handler)
 
 
-def _patched_client(monkeypatch: pytest.MonkeyPatch, handler) -> ExecutorClient:
+def _patched_client(
+    monkeypatch: pytest.MonkeyPatch,
+    handler,
+    operator_id: str | None = None,
+) -> ExecutorClient:
     """Return an ExecutorClient with httpx.AsyncClient swapped for a mock."""
     transport = _make_mock_transport(handler)
     original_init = httpx.AsyncClient.__init__
@@ -35,7 +39,7 @@ def _patched_client(monkeypatch: pytest.MonkeyPatch, handler) -> ExecutorClient:
         original_init(self, *args, **kwargs)
 
     monkeypatch.setattr(httpx.AsyncClient, "__init__", patched_init)
-    return ExecutorClient("http://test")
+    return ExecutorClient("http://test", operator_id=operator_id)
 
 
 @pytest.mark.asyncio
@@ -192,3 +196,64 @@ async def test_client_must_be_used_as_context_manager() -> None:
     cli = ExecutorClient("http://test")
     with pytest.raises(RuntimeError):
         await cli.health()
+
+
+# ---- PR-C4: operator_id passthrough ----
+
+
+@pytest.mark.asyncio
+async def test_post_includes_operator_id_when_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen_headers: dict[str, str] = {}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        if req.method == "POST":
+            seen_headers.update({k.lower(): v for k, v in req.headers.items()})
+        return httpx.Response(200, json={"aborted_executions": 0, "cancelled_orders": 0})
+
+    cli = _patched_client(monkeypatch, handler, operator_id="alice@desk")
+    async with cli:
+        await cli.emergency_stop()
+    assert seen_headers.get("x-operator-id") == "alice@desk", (
+        f"x-operator-id missing or wrong; saw: {seen_headers}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_post_omits_operator_id_when_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen_headers: dict[str, str] = {}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        if req.method == "POST":
+            seen_headers.update({k.lower(): v for k, v in req.headers.items()})
+        return httpx.Response(200, json={"aborted_executions": 0, "cancelled_orders": 0})
+
+    cli = _patched_client(monkeypatch, handler, operator_id=None)
+    async with cli:
+        await cli.emergency_stop()
+    assert "x-operator-id" not in seen_headers, (
+        f"x-operator-id should not be present when operator_id=None; saw: {seen_headers}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_does_not_include_operator_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    """GETs are read-only; only POST audit-tags the caller."""
+    seen_headers: dict[str, str] = {}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        if req.method == "GET":
+            seen_headers.update({k.lower(): v for k, v in req.headers.items()})
+        return httpx.Response(
+            200,
+            json={
+                "status": "ok",
+                "algorithms": ["market"],
+                "health": {},
+                "running_executions": 0,
+            },
+        )
+
+    cli = _patched_client(monkeypatch, handler, operator_id="alice@desk")
+    async with cli:
+        await cli.health()
+    assert "x-operator-id" not in seen_headers

--- a/tests/test_executor_client_live.py
+++ b/tests/test_executor_client_live.py
@@ -1,14 +1,19 @@
 """End-to-end smoke test: spins up the Rust executor-server and drives it
 via the Python connector.
 
-This test is marked ``slow`` and ``live`` so CI skips it by default
-(CI runs ``pytest -m "not live and not slow"``). Run locally with::
+PR-C4 (2026-05-05): the mock-mode e2e path is now safe enough for CI —
+it never touches HL, just exercises the Python ↔ Rust round-trip. Tests
+keep the ``slow`` marker so a developer can opt out via
+``pytest -m "not slow"`` if they only care about contract tests.
 
-    cargo build -p executor-server --release
-    pytest tests/test_executor_client_live.py -m live
+CI runs ``pytest -m "not live"`` and builds ``executor-server --release``
+beforehand. The ``live`` marker remains reserved for tests that hit real
+HL endpoints.
 
 The fixture finds a free port, starts the server, waits for /v1/health to
-come up, runs the test, and tears the server down on exit.
+come up, runs the test, and tears the server down on exit. PR-C3 made
+``emergency_stop`` mutate global server state (``shutdown_initiated``),
+so the fixture is **function-scoped** — every test gets a fresh server.
 """
 
 from __future__ import annotations
@@ -50,9 +55,13 @@ def _server_binary() -> Path:
     )
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def running_server() -> Iterator[str]:
-    """Start the executor-server, yield its base URL, tear it down."""
+    """Start the executor-server, yield its base URL, tear it down.
+
+    Function-scoped because PR-C3 makes emergency_stop mutate global state
+    (``ServerState::shutdown_initiated``). A module-scoped fixture would
+    leak that state between tests."""
     try:
         binary = _server_binary()
     except FileNotFoundError as e:
@@ -89,7 +98,6 @@ def running_server() -> Iterator[str]:
             proc.kill()
 
 
-@pytest.mark.live
 @pytest.mark.slow
 @pytest.mark.asyncio
 async def test_e2e_health_and_algorithms(running_server: str) -> None:
@@ -100,7 +108,6 @@ async def test_e2e_health_and_algorithms(running_server: str) -> None:
         assert n in body["algorithms"]
 
 
-@pytest.mark.live
 @pytest.mark.slow
 @pytest.mark.asyncio
 async def test_e2e_unknown_algorithm_400(running_server: str) -> None:
@@ -114,7 +121,6 @@ async def test_e2e_unknown_algorithm_400(running_server: str) -> None:
             )
 
 
-@pytest.mark.live
 @pytest.mark.slow
 @pytest.mark.asyncio
 async def test_e2e_emergency_stop_with_no_running(running_server: str) -> None:
@@ -124,7 +130,6 @@ async def test_e2e_emergency_stop_with_no_running(running_server: str) -> None:
     assert body["cancelled_orders"] == 0
 
 
-@pytest.mark.live
 @pytest.mark.slow
 @pytest.mark.asyncio
 async def test_e2e_market_book_returns_404(running_server: str) -> None:
@@ -133,7 +138,6 @@ async def test_e2e_market_book_returns_404(running_server: str) -> None:
             await cli.book("BTC")
 
 
-@pytest.mark.live
 @pytest.mark.slow
 @pytest.mark.asyncio
 async def test_e2e_start_market_then_cancel(running_server: str) -> None:
@@ -164,3 +168,48 @@ async def _sleep(seconds: float) -> None:
     import asyncio
 
     await asyncio.sleep(seconds)
+
+
+# ---- PR-C4: Python e2e for PR-C3 features (operator_id audit, idempotent
+#      emergency_stop, 503 after stop) ----
+
+
+@pytest.mark.slow
+@pytest.mark.asyncio
+async def test_e2e_emergency_stop_with_operator_id(running_server: str) -> None:
+    """operator_id passes through Python connector → server audit log.
+    The server doesn't echo it, so this just verifies the code path doesn't
+    blow up on either side."""
+    async with ExecutorClient(running_server, operator_id="alice@desk") as cli:
+        body = await cli.emergency_stop()
+    assert body["aborted_executions"] == 0
+    assert body["cancelled_orders"] == 0
+
+
+@pytest.mark.slow
+@pytest.mark.asyncio
+async def test_e2e_idempotent_emergency_stop(running_server: str) -> None:
+    """PR-C3: a second emergency_stop call after the first must be a no-op."""
+    async with ExecutorClient(running_server) as cli:
+        first = await cli.emergency_stop()
+        second = await cli.emergency_stop()
+    # First call may or may not have running executions to abort (typically 0
+    # in this fixture, but accept anything ≥ 0). Second must be (0, 0).
+    assert first["aborted_executions"] >= 0
+    assert second["aborted_executions"] == 0
+    assert second["cancelled_orders"] == 0
+
+
+@pytest.mark.slow
+@pytest.mark.asyncio
+async def test_e2e_503_after_emergency_stop(running_server: str) -> None:
+    """PR-C3: start_exec must return 503 once emergency_stop has fired."""
+    async with ExecutorClient(running_server) as cli:
+        await cli.emergency_stop()
+        with pytest.raises(Exception, match="HTTP 503"):
+            await cli.start(
+                algorithm=Algorithm.MARKET,
+                symbol="BTC",
+                intent=Intent.OPEN,
+                target_size="0.001",
+            )


### PR DESCRIPTION
## Summary

**Phase 3.5 を完成させる最終 PR**. PR-A 〜 PR-C4 完了をもって executor-server は **production 投入可能状態** に到達.

3 件を 1 PR で束ねる:

1. **multi-symbol cancel testnet live test placeholder** — ETH + BTC を同時 place → \`cancel_orders(&[c1, c2])\` 単一バッチで両 cancel. 既存 master EOA positions 不変も検証. \`#[cfg(feature = "live")]\`, ユーザー手動実行のみ.
2. **Python connector \`operator_id\` 全 POST** — \`X-Operator-ID\` header. GET は無タグ. server 側で \`start_exec\` / \`cancel_exec\` でも audit log.
3. **Python e2e tests を CI に組み込み** (Gemini deep flip 採用) — mock 限定で flaky にならない. session-scoped \`cargo build --release\` でビルドキャッシュ. CI 時間 +30s 程度.

### Gemini deep review

\`review_log\` に記録. 6 論点中 1 で flip:
- **Q3+Q8**: Claude は CI 除外を推奨, Gemini は **CI に含める (mock + cargo cache)** を強推奨 → 採用

他 5 論点 (testnet 1-shot key / Step A only / 全 POST / by_oid 別 PR / 完成判定) は Claude 推奨を Gemini 同意.

### 主要変更

- \`src/executor/client.py\`: \`ExecutorClient.__init__(operator_id=None)\`, \`_post\` で \`X-Operator-ID\` injection
- \`executor-server::routes\`: \`start_exec\` / \`cancel_exec\` に \`HeaderMap\` extractor + \`tracing::info!(operator,...)\`
- \`tests/test_executor_client_live.py\`: \`@pytest.mark.live\` 削除. \`running_server\` fixture を function scope に変更. PR-C3 関連 e2e tests 3 件追加
- \`.github/workflows/ci.yml\`: python job に Rust toolchain + cargo cache + \`cargo build --release -p executor-server\` 追加. CI marker filter \`-m "not live"\`
- \`scripts/check_ci_local.sh\`: 同期 (CI と一致)
- \`executor/crates/executor-hl/tests/live_emergency_stop_multi_testnet.rs\` (新規): testnet multi-cancel placeholder
- \`scripts/load-env-testnet.sh\` (新規): testnet PK loader, mainnet 鍵と完全分離

### テスト集計

- Rust workspace: **173 tests pass** (PR-C3 から変化なし)
- Python \`pytest -m "not live"\`: **8 e2e (5 既存 + 3 新規) + 11 mock + その他 全 pass**, ~1.4s
- \`cargo fmt --check\` / \`cargo clippy -D warnings\` / \`scripts/check_ci_local.sh\` 全クリーン

### Phase 3.5 完成宣言

| Stage | PR | 内容 |
|---|---|---|
| ✅ A | #69 | mainnet read-only parser |
| ✅ B1 | #70 | EIP-712 signer (byte-identical 10/10) |
| ✅ B2a | #71 | place_orders/cancel_orders + mockito |
| ✅ B2b | #72 | mainnet 1-round-trip 実機実証 |
| ✅ C1 | #73 | MetaCache + real mode 切替 |
| ✅ C2 | #74 | symbol allowlist + size cap |
| ✅ C3 | #75 | baseline-diff guard + idempotent emergency_stop |
| ✅ C4 | this | multi-cancel placeholder + e2e CI + operator_id |

mainnet 投入手順:
\`\`\`bash
source scripts/load-env.sh
cd executor
cargo run -p executor-server -- --mode real --base mainnet \\
  --mainnet-allow-symbols ETH \\
  --mainnet-max-notional-usd 20 \\
  --master-address 0xfe3e32cd...
\`\`\`

Python 接続:
\`\`\`python
async with ExecutorClient("http://127.0.0.1:8085", operator_id="alice@desk") as cli:
    resp = await cli.start("market", "ETH", "open", "0.005")
\`\`\`

### Phase 4 想定 (未実装)
- PR-D1: WS subscriber 本実装
- PR-D2: 片肺リスク (multi-order partial failure) 検知 + 自動 recovery
- PR-D3: by_oid cancel 経路
- PR-D4: signal handler + graceful shutdown
- PR-D5: HIP-3 multi-dex MetaCache

## Test plan

- [x] \`cargo test --workspace\` (173 pass)
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` (clean)
- [x] \`cargo fmt --all -- --check\` (clean)
- [x] Python \`pytest -m "not live"\` (e2e 8 件含み全 pass)
- [x] \`scripts/check_ci_local.sh\` (green)
- [x] \`cargo build --release -p executor-server\` succeeds (binary 36MB 程度)
- [ ] (CI) python job が新 cargo cache + binary build + e2e 込で green
- [ ] (ユーザー手動 testnet) \`source scripts/load-env-testnet.sh && cargo test --features live live_testnet_multi_cancel_two_symbols\` で multi-cancel 経路実機証明

🤖 Generated with [Claude Code](https://claude.com/claude-code)